### PR TITLE
Create multiple files in parallel

### DIFF
--- a/src/HttpGenerator/GenerateCommand.cs
+++ b/src/HttpGenerator/GenerateCommand.cs
@@ -43,11 +43,11 @@ public class GenerateCommand : AsyncCommand<Settings>
             if (!string.IsNullOrWhiteSpace(settings.OutputFolder) && !Directory.Exists(settings.OutputFolder))
                 Directory.CreateDirectory(settings.OutputFolder);
 
-            foreach (var file in result.Files)
-            {
-                var outputFile = Path.Combine(settings.OutputFolder!, file.Filename);
-                await File.WriteAllTextAsync(outputFile, file.Content);
-            }
+            await Task.WhenAll(
+                result.Files.Select(
+                    file => File.WriteAllTextAsync(
+                        Path.Combine(settings.OutputFolder!, file.Filename),
+                        file.Content)));
 
             AnsiConsole.MarkupLine($"[green]Files: {result.Files.Count}[/]");
             AnsiConsole.MarkupLine($"[green]Duration: {stopwatch.Elapsed}{Crlf}[/]");


### PR DESCRIPTION
Changed the file writing in `GenerateCommand` from a sequential for-each loop to a parallel `Task.WhenAll` operation. This change was made to improve performance by writing multiple files concurrently, especially when working with a large number of files.