### PR TITLE
Update output filenames to be prefixed with HTTP Method

### DIFF
--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -10,7 +10,7 @@ public static class HttpFileGenerator
     {
         var document = await OpenApiDocumentFactory.CreateAsync(settings.OpenApiPath);
         var generator = new CSharpClientGenerator(document, new CSharpClientGeneratorSettings());
-        generator.BaseSettings.OperationNameGenerator = new OperationNameGenerator(document);
+        generator.BaseSettings.OperationNameGenerator = new OperationNameGenerator();
 
         var baseUrl = settings.BaseUrl + document.Servers?.FirstOrDefault()?.Url;
 

--- a/src/HttpGenerator.Core/OperationNameGenerator.cs
+++ b/src/HttpGenerator.Core/OperationNameGenerator.cs
@@ -33,7 +33,10 @@ internal class OperationNameGenerator : IOperationNameGenerator
                 .ConvertKebabCaseToPascalCase()
                 .ConvertRouteToCamelCase()
                 .ConvertSpacesToPascalCase()
-                .Prefix(httpMethod.ToLowerInvariant().CapitalizeFirstCharacter());
+                .Prefix(
+                    httpMethod
+                        .ToLowerInvariant()
+                        .CapitalizeFirstCharacter());
         }
         catch (Exception e)
         {

--- a/src/HttpGenerator.Core/OperationNameGenerator.cs
+++ b/src/HttpGenerator.Core/OperationNameGenerator.cs
@@ -10,12 +10,6 @@ internal class OperationNameGenerator : IOperationNameGenerator
     private readonly IOperationNameGenerator defaultGenerator =
         new MultipleClientsFromOperationIdOperationNameGenerator();
 
-    public OperationNameGenerator(OpenApiDocument document)
-    {
-        if (CheckForDuplicateOperationIds(document))
-            defaultGenerator = new MultipleClientsFromFirstTagAndPathSegmentsOperationNameGenerator();
-    }
-
     [ExcludeFromCodeCoverage]
     public bool SupportsMultipleClients => throw new NotImplementedException();
 
@@ -38,7 +32,8 @@ internal class OperationNameGenerator : IOperationNameGenerator
                 .CapitalizeFirstCharacter()
                 .ConvertKebabCaseToPascalCase()
                 .ConvertRouteToCamelCase()
-                .ConvertSpacesToPascalCase();
+                .ConvertSpacesToPascalCase()
+                .Prefix(httpMethod.ToLowerInvariant().CapitalizeFirstCharacter());
         }
         catch (Exception e)
         {

--- a/src/HttpGenerator.Core/StringExtensions.cs
+++ b/src/HttpGenerator.Core/StringExtensions.cs
@@ -44,5 +44,12 @@ public static class StringExtensions
         return string.Join(string.Empty, parts);
     }
 
-    public static string Prefix(this string str, string prefix) => prefix + str;
+    public static string Prefix(this string str, string prefix)
+    {
+        if (str.StartsWith(prefix))
+        {
+            return str;
+        }
+        return prefix + str;
+    }
 }

--- a/src/HttpGenerator.Core/StringExtensions.cs
+++ b/src/HttpGenerator.Core/StringExtensions.cs
@@ -43,4 +43,6 @@ public static class StringExtensions
 
         return string.Join(string.Empty, parts);
     }
+
+    public static string Prefix(this string str, string prefix) => prefix + str;
 }

--- a/src/HttpGenerator/GenerateCommand.cs
+++ b/src/HttpGenerator/GenerateCommand.cs
@@ -46,7 +46,7 @@ public class GenerateCommand : AsyncCommand<Settings>
             await Task.WhenAll(
                 result.Files.Select(
                     file => File.WriteAllTextAsync(
-                        Path.Combine(settings.OutputFolder!, file.Filename),
+                        Path.Combine(settings.OutputFolder, file.Filename),
                         file.Content)));
 
             AnsiConsole.MarkupLine($"[green]Files: {result.Files.Count}[/]");


### PR DESCRIPTION
Several changes have been made to the code. In `GenerateCommand`, null assertion (!) was removed considering `OutputFolder` will always have a value. Also, a new utility method, 'Prefix', is added in `StringExtensions` to provide prefixing functionality. The major change was in `OperationNameGenerator` where the method of generating default operation names has been changed - a prefix is added to help distinguish between similar operation names. In `HttpFileGenerator`, an instance of `OperationNameGenerator` is no longer initialized using the document parameter, following the refactoring of `OperationNameGenerator`.