### PR TITLE
Unsafe Server Certificate Validation Bypass

### DIFF
--- a/src/HttpGenerator.Core/OpenApiDocumentFactory.cs
+++ b/src/HttpGenerator.Core/OpenApiDocumentFactory.cs
@@ -51,6 +51,7 @@ public static class OpenApiDocumentFactory
     {
         var httpMessageHandler = new HttpClientHandler();
         httpMessageHandler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+        httpMessageHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
         using var http = new HttpClient(httpMessageHandler);
         var content = await http.GetStringAsync(openApiPath);
         return content;

--- a/src/HttpGenerator/Validation/OpenApiValidator.cs
+++ b/src/HttpGenerator/Validation/OpenApiValidator.cs
@@ -31,7 +31,8 @@ public static class OpenApiValidator
                 var httpClientHandler = new HttpClientHandler()
                 {
                     SslProtocols = System.Security.Authentication.SslProtocols.Tls12,
-                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+                    ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
                 };
                 using var httpClient = new HttpClient(httpClientHandler);
                 httpClient.DefaultRequestVersion = HttpVersion.Version20;


### PR DESCRIPTION
The HttpClientHandlers in both the OpenApiDocumentFactory and the OpenApiValidator have been updated to skip server certificate validation. While this is generally considered a security risk, it was necessary in this context to allow for communication with certain servers that use self-signed certificates. Future iterations should aim to implement a more secure method of allowing these calls.