### PR TITLE
Include operation summary or description in generated .http files

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -27,7 +27,6 @@ jobs:
   
   file:
     strategy:
-      fail-fast: false
       matrix:
         format: [json, yaml]
         version: [v2.0, v3.0]
@@ -58,7 +57,6 @@ jobs:
   
   url:
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         openapi_url: [

--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -127,7 +127,7 @@ public static class HttpFileGenerator
     {
         var request = $"### {verb.ToUpperInvariant()} {kv.Key} Request";
         var length = request.Length + 2;
-        length = Math.Max(length, Math.Max(operation.Summary.Length, operation.Description.Length));
+        length = Math.Max(length, Math.Max(operation.Summary?.Length ?? 0, operation.Description?.Length ?? 0));
 
         for (var i = 0; i < length; i++)
         {

--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -53,7 +53,7 @@ public static class HttpFileGenerator
         {
             code.AppendLine($"@authorization = {settings.AuthorizationHeader}");
         }
-        
+
         code.AppendLine();
     }
 
@@ -79,7 +79,7 @@ public static class HttpFileGenerator
                 var code = new StringBuilder();
                 WriteFileHeaders(settings, code);
                 code.AppendLine(GenerateRequest(settings, baseUrl, verb, kv, operation));
-                
+
                 files.Add(new HttpFile(filename, code.ToString()));
             }
         }
@@ -95,8 +95,7 @@ public static class HttpFileGenerator
         OpenApiOperation operation)
     {
         var code = new StringBuilder();
-        code.AppendLine($"### {verb.ToUpperInvariant()} {kv.Key} Request");
-        code.AppendLine();
+        AppendSummary(verb, kv, operation, code);
         code.AppendLine($"{verb.ToUpperInvariant()} {baseUrl}{kv.Key}");
         code.AppendLine("Content-Type: @contentType");
 
@@ -118,5 +117,37 @@ public static class HttpFileGenerator
 
         code.AppendLine(requestBodyJson);
         return code.ToString();
+    }
+
+    private static void AppendSummary(
+        string verb,
+        KeyValuePair<string, OpenApiPathItem> kv,
+        OpenApiOperation operation,
+        StringBuilder code)
+    {
+        var request = $"### {verb.ToUpperInvariant()} {kv.Key} Request";
+        var length = request.Length + 2;
+        length = Math.Max(length, Math.Max(operation.Summary.Length, operation.Description.Length));
+
+        for (var i = 0; i < length; i++)
+        {
+            code.Insert(0, "#");
+        }
+
+        code.AppendLine();
+        code.AppendLine(request);
+
+        if (!string.IsNullOrWhiteSpace(operation.Summary) ||
+            !string.IsNullOrWhiteSpace(operation.Description))
+        {
+            code.AppendLine($"### {operation.Summary ?? operation.Description}");
+        }
+
+        for (var i = 0; i < length; i++)
+        {
+            code.Insert(code.Length, "#");
+        }
+
+        code.AppendLine(Environment.NewLine);
     }
 }

--- a/src/HttpGenerator.Tests/SwaggerPetstoreTests.cs
+++ b/src/HttpGenerator.Tests/SwaggerPetstoreTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using FluentAssertions.Execution;
 using HttpGenerator.Core;
 using HttpGenerator.Tests.Resources;
 
@@ -35,8 +36,14 @@ public class SwaggerPetstoreTests
     public async Task Can_Generate_Code(Samples version, string filename, OutputType outputType)
     {
         var generateCode = await GenerateCode(version, filename, outputType);
+        
+        using var scope = new AssertionScope();
         generateCode.Should().NotBeNull();
         generateCode.Files.Should().NotBeNullOrEmpty();
+        generateCode.Files
+            .All(file => file.Content.Count(c => c == '#') >= 6)
+            .Should()
+            .BeTrue();
     }
 
     [Theory]
@@ -58,8 +65,13 @@ public class SwaggerPetstoreTests
                 AuthorizationHeader = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
             });
 
+        using var scope = new AssertionScope();
         generateCode.Should().NotBeNull();
         generateCode.Files.Should().NotBeNullOrEmpty();
+        generateCode.Files
+            .All(file => file.Content.Count(c => c == '#') >= 6)
+            .Should()
+            .BeTrue();
     }
 
     private static async Task<GeneratorResult> GenerateCode(


### PR DESCRIPTION
Refactored the way in which summary lines are created for HTTP requests in the `HttpFileGenerator` class. This has been encapsulated into a new method, `AppendSummary()`, for better code organization and readability. This method also takes care of ensuring that summarization and description, when provided, are properly included in the generated summary line.

The new output of a generated .http file looks something like this:

```
@contentType = application/json
@authorization = Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9

############################
### PUT /pet Request
### Update an existing pet
############################

PUT https://localhost:5001/api/v3/pet
Content-Type: @contentType
Authorization: @authorization

{
  "id": 0,
  "name": "name",
  "category": {
    "id": 0,
    "name": "name"
  },
  "photoUrls": [
    ""
  ],
  "tags": [
    {
      "id": 0,
      "name": "name"
    }
  ],
  "status": "available"
}
```