### PR TITLE
Use the Authority part of OpenAPI path as the Base URL if not specified

### DIFF
--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -13,6 +13,13 @@ public static class HttpFileGenerator
         generator.BaseSettings.OperationNameGenerator = new OperationNameGenerator();
 
         var baseUrl = settings.BaseUrl + document.Servers?.FirstOrDefault()?.Url;
+        if (!Uri.IsWellFormedUriString(baseUrl, UriKind.Absolute) &&
+            settings.OpenApiPath.StartsWith("http"))
+        {
+            baseUrl = new Uri(settings.OpenApiPath)
+                          .GetLeftPart(UriPartial.Authority) +
+                      baseUrl;
+        }
 
         return settings.OutputType == OutputType.OneRequestPerFile
             ? GenerateMultipleFiles(settings, document, generator, baseUrl)

--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -14,7 +14,7 @@ public static class HttpFileGenerator
 
         var baseUrl = settings.BaseUrl + document.Servers?.FirstOrDefault()?.Url;
         if (!Uri.IsWellFormedUriString(baseUrl, UriKind.Absolute) &&
-            settings.OpenApiPath.StartsWith("http"))
+            settings.OpenApiPath.StartsWith("http", StringComparison.OrdinalIgnoreCase))
         {
             baseUrl = new Uri(settings.OpenApiPath)
                           .GetLeftPart(UriPartial.Authority) +

--- a/src/HttpGenerator.Tests/Resources/V3/SwaggerPetstore.json
+++ b/src/HttpGenerator.Tests/Resources/V3/SwaggerPetstore.json
@@ -11,12 +11,17 @@
       "name": "Apache 2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "1.0.5"
+    "version": "1.0.17"
   },
   "externalDocs": {
     "description": "Find out more about Swagger",
     "url": "http://swagger.io"
   },
+  "servers": [
+    {
+      "url": "/api/v3"
+    }
+  ],
   "tags": [
     {
       "name": "pet",
@@ -28,15 +33,15 @@
     },
     {
       "name": "store",
-      "description": "Operations about user"
-    },
-    {
-      "name": "user",
       "description": "Access to Petstore orders",
       "externalDocs": {
         "description": "Find out more about our store",
         "url": "http://swagger.io"
       }
+    },
+    {
+      "name": "user",
+      "description": "Operations about user"
     }
   ],
   "paths": {
@@ -192,6 +197,14 @@
           "200": {
             "description": "successful operation",
             "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -243,6 +256,14 @@
           "200": {
             "description": "successful operation",
             "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
               "application/json": {
                 "schema": {
                   "type": "array",
@@ -264,8 +285,7 @@
               "read:pets"
             ]
           }
-        ],
-        "deprecated": true
+        ]
       }
     },
     "/pet/{petId}": {
@@ -557,7 +577,7 @@
           "store"
         ],
         "summary": "Find purchase order by ID",
-        "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions",
+        "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.",
         "operationId": "getOrderById",
         "parameters": [
           {
@@ -575,6 +595,11 @@
           "200": {
             "description": "successful operation",
             "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Order"
@@ -748,7 +773,7 @@
                 }
               },
               "X-Expires-After": {
-                "description": "date in UTC when toekn expires",
+                "description": "date in UTC when token expires",
                 "schema": {
                   "type": "string",
                   "format": "date-time"
@@ -756,6 +781,11 @@
               }
             },
             "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "string"
+                }
+              },
               "application/json": {
                 "schema": {
                   "type": "string"
@@ -808,6 +838,11 @@
           "200": {
             "description": "successful operation",
             "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/User"

--- a/src/HttpGenerator.Tests/Resources/V3/SwaggerPetstore.yaml
+++ b/src/HttpGenerator.Tests/Resources/V3/SwaggerPetstore.yaml
@@ -1,38 +1,39 @@
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
-  description: |-
-    This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-    Swagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-    You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-    That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-    Some useful links:
-    - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-    - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
-  termsOfService: 'http://swagger.io/terms/'
+  description: "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.\
+    \  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io).\
+    \ In the third iteration of the pet store, we've switched to the design first\
+    \ approach!\nYou can now help us improve the API whether it's by making changes\
+    \ to the definition itself or to the code.\nThat way, with time, we can improve\
+    \ the API in general, and expose some of the new features in OAS3.\n\nSome useful\
+    \ links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n\
+    - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)"
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 1.0.5
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.17
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
+servers:
+  - url: /api/v3
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
   - name: store
-    description: Operations about user
-  - name: user
     description: Access to Petstore orders
     externalDocs:
       description: Find out more about our store
-      url: 'http://swagger.io'
+      url: http://swagger.io
+  - name: user
+    description: Operations about user
 paths:
   /pet:
     put:
@@ -55,7 +56,7 @@ paths:
               $ref: '#/components/schemas/Pet'
         required: true
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/xml:
@@ -64,16 +65,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Pet'
-        '400':
+        "400":
           description: Invalid ID supplied
-        '404':
+        "404":
           description: Pet not found
-        '405':
+        "405":
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -94,7 +95,7 @@ paths:
               $ref: '#/components/schemas/Pet'
         required: true
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/xml:
@@ -103,12 +104,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Pet'
-        '405':
+        "405":
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /pet/findByStatus:
     get:
       tags:
@@ -130,26 +131,32 @@ paths:
               - pending
               - sold
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Pet'
-        '400':
+        "400":
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /pet/findByTags:
     get:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: "Multiple tags can be provided with comma separated strings. Use\
+        \ tag1, tag2, tag3 for testing."
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -162,22 +169,26 @@ paths:
             items:
               type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Pet'
-        '400':
+        "400":
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-      deprecated: true
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -193,26 +204,29 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
             application/json:
               schema:
                 $ref: '#/components/schemas/Pet'
-        '400':
+        "400":
           description: Invalid ID supplied
-        '404':
+        "404":
           description: Pet not found
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
       summary: Updates a pet in the store with form data
-      description: ''
+      description: ""
       operationId: updatePetWithForm
       parameters:
         - name: petId
@@ -233,22 +247,22 @@ paths:
           schema:
             type: string
       responses:
-        '405':
+        "405":
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
       summary: Deletes a pet
-      description: ''
+      description: ""
       operationId: deletePet
       parameters:
         - name: api_key
           in: header
-          description: ''
+          description: ""
           required: false
           schema:
             type: string
@@ -260,18 +274,18 @@ paths:
             type: integer
             format: int64
       responses:
-        '400':
+        "400":
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
       summary: uploads an image
-      description: ''
+      description: ""
       operationId: uploadFile
       parameters:
         - name: petId
@@ -294,7 +308,7 @@ paths:
               type: string
               format: binary
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
@@ -302,8 +316,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /store/inventory:
     get:
       tags:
@@ -312,7 +326,7 @@ paths:
       description: Returns a map of status codes to quantities
       operationId: getInventory
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
@@ -342,20 +356,21 @@ paths:
             schema:
               $ref: '#/components/schemas/Order'
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Order'
-        '405':
+        "405":
           description: Invalid input
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
       summary: Find purchase order by ID
-      description: For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
+      description: For valid response try integer IDs with value <= 5 or > 10. Other
+        values will generate exceptions.
       operationId: getOrderById
       parameters:
         - name: orderId
@@ -366,21 +381,25 @@ paths:
             type: integer
             format: int64
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Order'
             application/json:
               schema:
                 $ref: '#/components/schemas/Order'
-        '400':
+        "400":
           description: Invalid ID supplied
-        '404':
+        "404":
           description: Order not found
     delete:
       tags:
         - store
       summary: Delete purchase order by ID
-      description: For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+      description: For valid response try integer IDs with value < 1000. Anything
+        above 1000 or nonintegers will generate API errors
       operationId: deleteOrder
       parameters:
         - name: orderId
@@ -391,9 +410,9 @@ paths:
             type: integer
             format: int64
       responses:
-        '400':
+        "400":
           description: Invalid ID supplied
-        '404':
+        "404":
           description: Order not found
   /user:
     post:
@@ -439,7 +458,7 @@ paths:
               items:
                 $ref: '#/components/schemas/User'
       responses:
-        '200':
+        "200":
           description: Successful operation
           content:
             application/xml:
@@ -455,7 +474,7 @@ paths:
       tags:
         - user
       summary: Logs user into the system
-      description: ''
+      description: ""
       operationId: loginUser
       parameters:
         - name: username
@@ -471,7 +490,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           headers:
             X-Rate-Limit:
@@ -480,33 +499,36 @@ paths:
                 type: integer
                 format: int32
             X-Expires-After:
-              description: date in UTC when toekn expires
+              description: date in UTC when token expires
               schema:
                 type: string
                 format: date-time
           content:
+            application/xml:
+              schema:
+                type: string
             application/json:
               schema:
                 type: string
-        '400':
+        "400":
           description: Invalid username/password supplied
   /user/logout:
     get:
       tags:
         - user
       summary: Logs out current logged in user session
-      description: ''
+      description: ""
       operationId: logoutUser
       parameters: []
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
       summary: Get user by user name
-      description: ''
+      description: ""
       operationId: getUserByName
       parameters:
         - name: username
@@ -516,15 +538,18 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: successful operation
           content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/User'
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
-        '400':
+        "400":
           description: Invalid username supplied
-        '404':
+        "404":
           description: User not found
     put:
       tags:
@@ -568,9 +593,9 @@ paths:
           schema:
             type: string
       responses:
-        '400':
+        "400":
           description: Invalid username supplied
-        '404':
+        "404":
           description: User not found
 components:
   schemas:
@@ -637,7 +662,7 @@ components:
           example: CA
         zip:
           type: string
-          example: '94301'
+          example: "94301"
       xml:
         name: address
     Category:
@@ -673,10 +698,10 @@ components:
           example: john@email.com
         password:
           type: string
-          example: '12345'
+          example: "12345"
         phone:
           type: string
-          example: '12345'
+          example: "12345"
         userStatus:
           type: integer
           description: User Status
@@ -767,10 +792,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore3.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore3.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/src/HttpGenerator.Tests/SwaggerPetstoreTests.cs
+++ b/src/HttpGenerator.Tests/SwaggerPetstoreTests.cs
@@ -62,6 +62,33 @@ public class SwaggerPetstoreTests
         generateCode.Files.Should().NotBeNullOrEmpty();
     }
 
+    [Theory]
+    [InlineData(HttpsUrlPrefix + "petstore.json", OutputType.OneRequestPerFile)]
+    [InlineData(HttpsUrlPrefix + "petstore.yaml", OutputType.OneRequestPerFile)]
+    [InlineData(HttpUrlPrefix + "petstore.json", OutputType.OneRequestPerFile)]
+    [InlineData(HttpUrlPrefix + "petstore.yaml", OutputType.OneRequestPerFile)]
+    [InlineData(HttpsUrlPrefix + "petstore.json", OutputType.OneFile)]
+    [InlineData(HttpsUrlPrefix + "petstore.yaml", OutputType.OneFile)]
+    [InlineData(HttpUrlPrefix + "petstore.json", OutputType.OneFile)]
+    [InlineData(HttpUrlPrefix + "petstore.yaml", OutputType.OneFile)]
+    public async Task Files_Generated_From_Url_Uses_OpenApiPath_Authority_As_For_BaseUrl(
+        string url,
+        OutputType outputType)
+    {
+        var generateCode = await HttpFileGenerator.Generate(
+            new GeneratorSettings
+            {
+                OpenApiPath = url,
+                OutputType = outputType
+            });
+
+        generateCode
+            .Files
+            .All(file => file.Content.Contains(new Uri(url).GetLeftPart(UriPartial.Authority)))
+            .Should()
+            .BeTrue();
+    }
+
     private static async Task<GeneratorResult> GenerateCode(
         Samples version,
         string filename,


### PR DESCRIPTION
Several tests were added to validate the handling of URLs in the HttpFileGenerator. These tests check that files are generated correctly for both http and https URLs using different output types. Additionally, modified the HttpFileGenerator to correct the base URL when necessary. If the base URL is not a well-formed URL, and if the 'OpenApiPath' starts with "http", the base URL is updated to use the authority detail from the 'OpenApiPath', ensuring the correct URL is used for API calls.

Updated the SwaggerPetstore.json and SwaggerPetstore.yaml specification files with the latest version of the spec from https://petstore3.swagger.io