### PR TITLE
Show Operation Description as a separate line

### DIFF
--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -132,9 +132,17 @@ public static class HttpFileGenerator
         OpenApiOperation operation,
         StringBuilder code)
     {
-        var request = $"### {verb.ToUpperInvariant()} {kv.Key} Request";
-        var length = request.Length + 2;
-        length = Math.Max(length, Math.Max(operation.Summary?.Length ?? 0, operation.Description?.Length ?? 0));
+        const int padding = 2;
+        const string summary = "### Summary: ";
+        const string description = "### Description: ";
+        
+        var request = $"### Request: {verb.ToUpperInvariant()} {kv.Key}";
+        var length = request.Length + padding;
+        length = Math.Max(
+            length,
+            Math.Max(
+                (operation.Summary?.Length ?? 0) + summary.Length + padding,
+                (operation.Description?.Length ?? 0) + description.Length + padding));
 
         for (var i = 0; i < length; i++)
         {
@@ -144,10 +152,14 @@ public static class HttpFileGenerator
         code.AppendLine();
         code.AppendLine(request);
 
-        if (!string.IsNullOrWhiteSpace(operation.Summary) ||
-            !string.IsNullOrWhiteSpace(operation.Description))
+        if (!string.IsNullOrWhiteSpace(operation.Summary))
         {
-            code.AppendLine($"### {operation.Summary ?? operation.Description}");
+            code.AppendLine($"{summary}{operation.Summary}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(operation.Description))
+        {
+            code.AppendLine($"{description}{operation.Description}");
         }
 
         for (var i = 0; i < length; i++)


### PR DESCRIPTION
Updated the HttpFileGenerator to include separate lines for summary and description as part of the request definition. Previous approach did not differentiate between summary and description fields which could create confusion. This change improves readability and clarifies individual segments of the HTTP request.