### PR TITLE
Suggest using --skip-validation when validation fails

### DIFF
--- a/src/HttpGenerator.Tests/GenerateCommandTests.cs
+++ b/src/HttpGenerator.Tests/GenerateCommandTests.cs
@@ -55,11 +55,11 @@ public class GenerateCommandTests
     [Inline("V31.non-oauth-scopes.json", OutputType.OneRequestPerFile)]
     [Inline("V31.non-oauth-scopes.yaml", OutputType.OneRequestPerFile)]
     [Inline("V31.webhook-example.json", OutputType.OneRequestPerFile)]
-    [Inline("V31.webhook-example.json", OutputType.OneRequestPerFile)]
+    [Inline("V31.webhook-example.yaml", OutputType.OneRequestPerFile)]
     [Inline("V31.non-oauth-scopes.json", OutputType.OneFile)]
     [Inline("V31.non-oauth-scopes.yaml", OutputType.OneFile)]
     [Inline("V31.webhook-example.json", OutputType.OneFile)]
-    [Inline("V31.webhook-example.json", OutputType.OneFile)]
+    [Inline("V31.webhook-example.yaml", OutputType.OneFile)]
     public async Task Should_Generate_Code_From_File_V31_Spec_When_Validation_Skipped(
         string manifestResourceStreamName,
         OutputType outputType,
@@ -81,11 +81,11 @@ public class GenerateCommandTests
     [Inline("V31.non-oauth-scopes.json", OutputType.OneRequestPerFile)]
     [Inline("V31.non-oauth-scopes.yaml", OutputType.OneRequestPerFile)]
     [Inline("V31.webhook-example.json", OutputType.OneRequestPerFile)]
-    [Inline("V31.webhook-example.json", OutputType.OneRequestPerFile)]
+    [Inline("V31.webhook-example.yaml", OutputType.OneRequestPerFile)]
     [Inline("V31.non-oauth-scopes.json", OutputType.OneFile)]
     [Inline("V31.non-oauth-scopes.yaml", OutputType.OneFile)]
     [Inline("V31.webhook-example.json", OutputType.OneFile)]
-    [Inline("V31.webhook-example.json", OutputType.OneFile)]
+    [Inline("V31.webhook-example.yaml", OutputType.OneFile)]
     public async Task Should_Fail_Validating_V31_Spec(
         string manifestResourceStreamName,
         OutputType outputType,

--- a/src/HttpGenerator.Tests/GenerateCommandTests.cs
+++ b/src/HttpGenerator.Tests/GenerateCommandTests.cs
@@ -52,6 +52,57 @@ public class GenerateCommandTests
     }
 
     [Theory]
+    [Inline("V31.non-oauth-scopes.json", OutputType.OneRequestPerFile)]
+    [Inline("V31.non-oauth-scopes.yaml", OutputType.OneRequestPerFile)]
+    [Inline("V31.webhook-example.json", OutputType.OneRequestPerFile)]
+    [Inline("V31.webhook-example.json", OutputType.OneRequestPerFile)]
+    [Inline("V31.non-oauth-scopes.json", OutputType.OneFile)]
+    [Inline("V31.non-oauth-scopes.yaml", OutputType.OneFile)]
+    [Inline("V31.webhook-example.json", OutputType.OneFile)]
+    [Inline("V31.webhook-example.json", OutputType.OneFile)]
+    public async Task Should_Generate_Code_From_File_V31_Spec_When_Validation_Skipped(
+        string manifestResourceStreamName,
+        OutputType outputType,
+        GenerateCommand sut,
+        CommandContext context,
+        Settings settings)
+    {
+        var json = EmbeddedResources.GetStringFromEmbeddedResource(manifestResourceStreamName);
+        settings.OpenApiPath = await TestFile.CreateSwaggerFile(json, manifestResourceStreamName);
+        settings.NoLogging = true;
+        settings.SkipValidation = true;
+
+        (await sut.ExecuteAsync(context, settings))
+            .Should()
+            .Be(0);
+    }
+
+    [Theory]
+    [Inline("V31.non-oauth-scopes.json", OutputType.OneRequestPerFile)]
+    [Inline("V31.non-oauth-scopes.yaml", OutputType.OneRequestPerFile)]
+    [Inline("V31.webhook-example.json", OutputType.OneRequestPerFile)]
+    [Inline("V31.webhook-example.json", OutputType.OneRequestPerFile)]
+    [Inline("V31.non-oauth-scopes.json", OutputType.OneFile)]
+    [Inline("V31.non-oauth-scopes.yaml", OutputType.OneFile)]
+    [Inline("V31.webhook-example.json", OutputType.OneFile)]
+    [Inline("V31.webhook-example.json", OutputType.OneFile)]
+    public async Task Should_Fail_Validating_V31_Spec(
+        string manifestResourceStreamName,
+        OutputType outputType,
+        GenerateCommand sut,
+        CommandContext context,
+        Settings settings)
+    {
+        var json = EmbeddedResources.GetStringFromEmbeddedResource(manifestResourceStreamName);
+        settings.OpenApiPath = await TestFile.CreateSwaggerFile(json, manifestResourceStreamName);
+        settings.NoLogging = true;
+
+        (await sut.ExecuteAsync(context, settings))
+            .Should()
+            .NotBe(0);
+    }
+
+    [Theory]
     [Inline(HttpsUrlPrefix + "petstore.json", OutputType.OneRequestPerFile)]
     [Inline(HttpsUrlPrefix + "petstore.yaml", OutputType.OneRequestPerFile)]
     [Inline(HttpUrlPrefix + "petstore.json", OutputType.OneRequestPerFile)]

--- a/src/HttpGenerator.Tests/HttpGenerator.Tests.csproj
+++ b/src/HttpGenerator.Tests/HttpGenerator.Tests.csproj
@@ -33,6 +33,14 @@
     <EmbeddedResource Include="Resources\V3\SwaggerPetstore.yaml" />
     <EmbeddedResource Include="Resources\V3\SwaggerPetstoreWithDifferentHeaders.json" />
     <EmbeddedResource Include="Resources\V3\SwaggerPetstoreWithDifferentHeaders.yaml" />
+    <None Remove="Resources\V31\non-oauth-scopes.json" />
+    <EmbeddedResource Include="Resources\V31\non-oauth-scopes.json" />
+    <None Remove="Resources\V31\non-oauth-scopes.yaml" />
+    <EmbeddedResource Include="Resources\V31\non-oauth-scopes.yaml" />
+    <None Remove="Resources\V31\webhook-example.json" />
+    <EmbeddedResource Include="Resources\V31\webhook-example.json" />
+    <None Remove="Resources\V31\webhook-example.yaml" />
+    <EmbeddedResource Include="Resources\V31\webhook-example.yaml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HttpGenerator.Tests/Resources/EmbeddedResources.cs
+++ b/src/HttpGenerator.Tests/Resources/EmbeddedResources.cs
@@ -88,7 +88,12 @@ public static class EmbeddedResources
         }
     }
 
-
+    public static string GetStringFromEmbeddedResource(string name)
+    {
+        using var stream = GetStream("V31.webhook-example.json");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
 
     public static string GetSwaggerPetstore(Samples version)
     {

--- a/src/HttpGenerator.Tests/Resources/V31/non-oauth-scopes.json
+++ b/src/HttpGenerator.Tests/Resources/V31/non-oauth-scopes.json
@@ -1,0 +1,31 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Non-oAuth Scopes example",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "security": [
+          {
+            "bearerAuth": [
+              "read:users",
+              "public"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "jwt",
+        "description": "note: non-oauth scopes are not defined at the securityScheme level"
+      }
+    }
+  }
+}

--- a/src/HttpGenerator.Tests/Resources/V31/non-oauth-scopes.yaml
+++ b/src/HttpGenerator.Tests/Resources/V31/non-oauth-scopes.yaml
@@ -1,0 +1,19 @@
+openapi: 3.1.0
+info:
+  title: Non-oAuth Scopes example
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      security:
+        - bearerAuth:
+            - 'read:users'
+            - 'public'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: jwt
+      description: 'note: non-oauth scopes are not defined at the securityScheme level'
+

--- a/src/HttpGenerator.Tests/Resources/V31/webhook-example.json
+++ b/src/HttpGenerator.Tests/Resources/V31/webhook-example.json
@@ -1,0 +1,50 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Webhook Example",
+    "version": "1.0.0"
+  },
+  "webhooks": {
+    "newPet": {
+      "post": {
+        "requestBody": {
+          "description": "Information about a new pet in the system",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Return a 200 status to indicate that the data was received successfully"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/HttpGenerator.Tests/Resources/V31/webhook-example.yaml
+++ b/src/HttpGenerator.Tests/Resources/V31/webhook-example.yaml
@@ -1,0 +1,35 @@
+openapi: 3.1.0
+info:
+  title: Webhook Example
+  version: 1.0.0
+# Since OAS 3.1.0 the paths element isn't necessary. Now a valid OpenAPI Document can describe only paths, webhooks, or even only reusable components
+webhooks:
+  # Each webhook needs a name
+  newPet:
+    # This is a Path Item Object, the only difference is that the request is initiated by the API provider
+    post:
+      requestBody:
+        description: Information about a new pet in the system
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "200":
+          description: Return a 200 status to indicate that the data was received successfully
+
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+


### PR DESCRIPTION
A new catch block has been added to manage `OpenApiUnsupportedSpecVersionException` with appropriate error messages and tips. This advises the user to skip validation if they encounter such an exception due to unsupported versions of OpenAPI specifications.