### PR TITLE
Fix variable usage in generated .http files

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ In this example, the contents of `PostAddPet.http` looks like this:
 #############################################
 
 POST /api/v3/pet
-Content-Type: @contentType
+Content-Type: {{contentType}}
 
 {
   "id": 0,

--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -104,11 +104,11 @@ public static class HttpFileGenerator
         var code = new StringBuilder();
         AppendSummary(verb, kv, operation, code);
         code.AppendLine($"{verb.ToUpperInvariant()} {baseUrl}{kv.Key}");
-        code.AppendLine("Content-Type: @contentType");
+        code.AppendLine("Content-Type: {{contentType}}");
 
         if (!string.IsNullOrWhiteSpace(settings.AuthorizationHeader))
         {
-            code.AppendLine($"Authorization: @authorization");
+            code.AppendLine($"Authorization: {{authorization}}");
         }
 
         var contentType = operation.RequestBody?.Content?.Keys

--- a/src/HttpGenerator/README.md
+++ b/src/HttpGenerator/README.md
@@ -95,8 +95,8 @@ In this example, the contents of `PostAddPet.http` looks like this:
 ### Description: Add a new pet to the store
 #############################################
 
-POST /api/v3/pet
-Content-Type: @contentType
+POST https://petstore3.swagger.io/api/v3/pet
+Content-Type: {{contentType}}
 
 {
   "id": 0,


### PR DESCRIPTION
The previous use of "@" was an incorrect format for variable interpolation in strings. The changes applied correct the format to "{}" in the HttpFileGenerator class, and update all instances where this incorrect usage affected the Content-Type and Authorization lines in the HTTP request files.