### PR TITLE
Fix Authorization header format

### DIFF
--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -108,7 +108,7 @@ public static class HttpFileGenerator
 
         if (!string.IsNullOrWhiteSpace(settings.AuthorizationHeader))
         {
-            code.AppendLine($"Authorization: {{authorization}}");
+            code.AppendLine("Authorization: {{authorization}}");
         }
 
         var contentType = operation.RequestBody?.Content?.Keys
@@ -135,7 +135,7 @@ public static class HttpFileGenerator
         const int padding = 2;
         const string summary = "### Summary: ";
         const string description = "### Description: ";
-        
+
         var request = $"### Request: {verb.ToUpperInvariant()} {kv.Key}";
         var length = request.Length + padding;
         length = Math.Max(


### PR DESCRIPTION
String interpolation was removed from the Authorization header in HttpFileGenerator.cs as this was not intended and broke the output of the generated files.