### PR TITLE
Add support for acquiring authorization headers from Azure Entra ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ You can also use the `--azure-scope` and `azure-tenant-id` arguments internally 
 ```powershell
 httpgenerator `
   https://api.example.com/swagger/v1/swagger.json `
-  --azure-scope [Some Application ID URI]/.default`
+  --azure-scope [Some Application ID URI]/.default `
   --base-url https://api.example.com `
   --output ./HttpFiles 
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dotnet tool install --global httpgenerator
 
 ## Usage
 
-```
+```pwsh
 USAGE:
     httpgenerator [URL or input file] [OPTIONS]
 
@@ -34,6 +34,7 @@ EXAMPLES:
     httpgenerator https://petstore.swagger.io/v2/swagger.json
     httpgenerator https://petstore3.swagger.io/api/v3/openapi.json --base-url https://petstore3.swagger.io
     httpgenerator ./openapi.json --authorization-header Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+    httpgenerator ./openapi.json --azure-scope [Some Application ID URI]/.default
 
 ARGUMENTS:
     [URL or input file]    URL or file path to OpenAPI Specification file
@@ -49,6 +50,8 @@ OPTIONS:
         --content-type <CONTENT-TYPE>      application/json     Default Content-Type header to use for all requests                                                           
         --base-url <BASE-URL>                                   Default Base URL to use for all requests. Use this if the OpenAPI spec doesn't explicitly specify a server URL
         --output-type <OUTPUT-TYPE>        OneRequestPerFile    OneRequestPerFile generates one .http file per request. OneFile generates a single .http file for all requests
+        --azure-scope <SCOPE>                                   Azure Entra ID Scope to use for retrieving Access Token for Authorization header                              
+        --azure-tenant-id <TENANT-ID>                           Azure Entra ID Tenant ID to use for retrieving Access Token for Authorization header                          
 ```
 
 Running the following:

--- a/README.md
+++ b/README.md
@@ -152,6 +152,18 @@ az account get-access-token --scope [Some Application ID URI]/.default `
 }
 ```
 
+You can also use the `--azure-scope` and `azure-tenant` arguments which internally uses `DefaultAzureCredentials` from the `Microsoft.Extensions.Azure` NuGet package to retrieve an access token for the specified `scope`.
+
+```powershell
+httpgenerator `
+  https://api.example.com/swagger/v1/swagger.json `
+  --azure-scope [Some Application ID URI]/.default`
+  --base-url https://api.example.com `
+  --output ./HttpFiles 
+```
+
+This is unfortunately much slower than the approach above using Azure CLI directly and piping the output to `httpgenerator`. On the plus side, `DefaultAzureCredentials` also works using the account signed in with from Visual Studio
+
 ### Error Logging, Telemetry, and Privacy
 
 This tool collects errors and tracks features usages to service called [Exceptionless](https://exceptionless.com/)

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ az account get-access-token --scope [Some Application ID URI]/.default `
 }
 ```
 
-You can also use the `--azure-scope` and `azure-tenant` arguments which internally uses `DefaultAzureCredentials` from the `Microsoft.Extensions.Azure` NuGet package to retrieve an access token for the specified `scope`.
+You can also use the `--azure-scope` and `azure-tenant-id` arguments internally use `DefaultAzureCredentials` from the `Microsoft.Extensions.Azure` NuGet package to retrieve an access token for the specified `scope`.
 
 ```powershell
 httpgenerator `
@@ -161,8 +161,6 @@ httpgenerator `
   --base-url https://api.example.com `
   --output ./HttpFiles 
 ```
-
-This is unfortunately much slower than the approach above using Azure CLI directly and piping the output to `httpgenerator`. On the plus side, `DefaultAzureCredentials` also works using the account signed in with from Visual Studio
 
 ### Error Logging, Telemetry, and Privacy
 

--- a/src/HttpGenerator.Core/AzureEntraID.cs
+++ b/src/HttpGenerator.Core/AzureEntraID.cs
@@ -13,13 +13,19 @@ namespace HttpGenerator.Core
             try
             {
                 var request = new TokenRequestContext([scope], tenantId: tenantId);
-                var credentials = new DefaultAzureCredential(
-                    new DefaultAzureCredentialOptions
-                    {
-                        ExcludeEnvironmentCredential = true,
-                        ExcludeWorkloadIdentityCredential = true,
-                        ExcludeManagedIdentityCredential = true,
-                    });
+                var credentials = new ChainedTokenCredential(
+                    new AzureCliCredential(),
+                    new VisualStudioCredential(),
+                    new DefaultAzureCredential(
+                        new DefaultAzureCredentialOptions
+                        {
+                            ExcludeWorkloadIdentityCredential = true,
+                            ExcludeManagedIdentityCredential = true,
+                            ExcludeVisualStudioCredential = true,
+                            ExcludeEnvironmentCredential = true,
+                            ExcludeAzureCliCredential = true,
+                        }));
+                
                 var token = await credentials.GetTokenAsync(request, cancellationToken);
                 return token.Token;
             }

--- a/src/HttpGenerator.Core/AzureEntraID.cs
+++ b/src/HttpGenerator.Core/AzureEntraID.cs
@@ -1,8 +1,10 @@
-﻿using Azure.Core;
+﻿using System.Diagnostics.CodeAnalysis;
+using Azure.Core;
 using Azure.Identity;
 
 namespace HttpGenerator.Core
 {
+    [ExcludeFromCodeCoverage]
     public static class AzureEntraID
     {
         public static async Task<string?> TryGetAccessTokenAsync(

--- a/src/HttpGenerator.Core/AzureEntraID.cs
+++ b/src/HttpGenerator.Core/AzureEntraID.cs
@@ -1,0 +1,34 @@
+﻿using Azure.Core;
+using Azure.Identity;
+
+namespace HttpGenerator.Core
+{
+    public static class AzureEntraID
+    {
+        public static async Task<string?> TryGetAccessTokenAsync(
+            string tenantId,
+            string scope,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var request = new TokenRequestContext([scope], tenantId: tenantId);
+                var credentials = new DefaultAzureCredential(
+                    new DefaultAzureCredentialOptions
+                    {
+                        ExcludeEnvironmentCredential = true,
+                        ExcludeWorkloadIdentityCredential = true,
+                        ExcludeManagedIdentityCredential = true,
+                    });
+                var token = await credentials.GetTokenAsync(request, cancellationToken);
+                return token.Token;
+            }
+            catch (OperationCanceledException)
+            {
+                // Ignore
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/HttpGenerator.Core/HttpGenerator.Core.csproj
+++ b/src/HttpGenerator.Core/HttpGenerator.Core.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="NSwag.CodeGeneration.CSharp" Version="13.20.0" />
     <PackageReference Include="NSwag.Core.Yaml" Version="13.20.0" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.1" />
   </ItemGroup>
 
 </Project>

--- a/src/HttpGenerator/GenerateCommand.cs
+++ b/src/HttpGenerator/GenerateCommand.cs
@@ -94,6 +94,7 @@ public class GenerateCommand : AsyncCommand<Settings>
 
         try
         {
+            AnsiConsole.MarkupLine($"[green]Acquiring authorization header from Azure Entra ID[/]{Crlf}");
             using var listener = AzureEventSourceListener.CreateConsoleLogger();
             var token = await AzureEntraID
                 .TryGetAccessTokenAsync(
@@ -102,7 +103,10 @@ public class GenerateCommand : AsyncCommand<Settings>
                     CancellationToken.None);
 
             if (!string.IsNullOrWhiteSpace(token))
+            {
                 settings.AuthorizationHeader = $"Bearer {token}";
+                AnsiConsole.MarkupLine($"{Crlf}[green]Successfully acquired access token[/]{Crlf}");
+            }
         }
         catch (Exception exception)
         {

--- a/src/HttpGenerator/Program.cs
+++ b/src/HttpGenerator/Program.cs
@@ -55,6 +55,13 @@ internal static class Program
                         "--authorization-header",
                         "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
                     );
+
+                configuration
+                    .AddExample(
+                        "./openapi.json",
+                        "--azure-scope",
+                        "[Some Application ID URI]/.default"
+                    );
             });
 
         return app.Run(args);

--- a/src/HttpGenerator/README.md
+++ b/src/HttpGenerator/README.md
@@ -140,7 +140,7 @@ You can also use the `--azure-scope` and `azure-tenant-id` arguments internally 
 ```powershell
 httpgenerator `
   https://api.example.com/swagger/v1/swagger.json `
-  --azure-scope [Some Application ID URI]/.default`
+  --azure-scope [Some Application ID URI]/.default `
   --base-url https://api.example.com `
   --output ./HttpFiles 
 ```

--- a/src/HttpGenerator/README.md
+++ b/src/HttpGenerator/README.md
@@ -135,7 +135,7 @@ az account get-access-token --scope [Some Application ID URI]/.default `
 }
 ```
 
-You can also use the `--azure-scope` and `azure-tenant` arguments which internally uses `DefaultAzureCredentials` from the `Microsoft.Extensions.Azure` NuGet package to retrieve an access token for the specified `scope`.
+You can also use the `--azure-scope` and `azure-tenant-id` arguments internally use `DefaultAzureCredentials` from the `Microsoft.Extensions.Azure` NuGet package to retrieve an access token for the specified `scope`.
 
 ```powershell
 httpgenerator `
@@ -144,8 +144,6 @@ httpgenerator `
   --base-url https://api.example.com `
   --output ./HttpFiles 
 ```
-
-This is unfortunately much slower than the approach above using Azure CLI directly and piping the output to `httpgenerator`. On the plus side, `DefaultAzureCredentials` also works using the account signed in with from Visual Studio
 
 #
 

--- a/src/HttpGenerator/README.md
+++ b/src/HttpGenerator/README.md
@@ -6,7 +6,7 @@ Generate .http files from OpenAPI specifications
 
 ## Usage
 
-```sh
+```pwsh
 USAGE:
     httpgenerator [URL or input file] [OPTIONS]
 
@@ -17,6 +17,7 @@ EXAMPLES:
     httpgenerator https://petstore.swagger.io/v2/swagger.json
     httpgenerator https://petstore3.swagger.io/api/v3/openapi.json --base-url https://petstore3.swagger.io
     httpgenerator ./openapi.json --authorization-header Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+    httpgenerator ./openapi.json --azure-scope [Some Application ID URI]/.default
 
 ARGUMENTS:
     [URL or input file]    URL or file path to OpenAPI Specification file
@@ -32,6 +33,8 @@ OPTIONS:
         --content-type <CONTENT-TYPE>      application/json     Default Content-Type header to use for all requests                                                           
         --base-url <BASE-URL>                                   Default Base URL to use for all requests. Use this if the OpenAPI spec doesn't explicitly specify a server URL
         --output-type <OUTPUT-TYPE>        OneRequestPerFile    OneRequestPerFile generates one .http file per request. OneFile generates a single .http file for all requests
+        --azure-scope <SCOPE>                                   Azure Entra ID Scope to use for retrieving Access Token for Authorization header                              
+        --azure-tenant-id <TENANT-ID>                           Azure Entra ID Tenant ID to use for retrieving Access Token for Authorization header                          
 ```
 
 Running the following:

--- a/src/HttpGenerator/README.md
+++ b/src/HttpGenerator/README.md
@@ -135,6 +135,18 @@ az account get-access-token --scope [Some Application ID URI]/.default `
 }
 ```
 
+You can also use the `--azure-scope` and `azure-tenant` arguments which internally uses `DefaultAzureCredentials` from the `Microsoft.Extensions.Azure` NuGet package to retrieve an access token for the specified `scope`.
+
+```powershell
+httpgenerator `
+  https://api.example.com/swagger/v1/swagger.json `
+  --azure-scope [Some Application ID URI]/.default`
+  --base-url https://api.example.com `
+  --output ./HttpFiles 
+```
+
+This is unfortunately much slower than the approach above using Azure CLI directly and piping the output to `httpgenerator`. On the plus side, `DefaultAzureCredentials` also works using the account signed in with from Visual Studio
+
 #
 
 For tips and tricks on software development, check out [my blog](https://christianhelle.com)

--- a/src/HttpGenerator/Settings.cs
+++ b/src/HttpGenerator/Settings.cs
@@ -48,4 +48,12 @@ public class Settings : CommandSettings
     [DefaultValue(OutputType.OneRequestPerFile)]
     [AllowedValues(nameof(OutputType.OneRequestPerFile), nameof(OutputType.OneFile))]
     public OutputType OutputType { get; set; } = OutputType.OneRequestPerFile;
+    
+    [Description("Azure Entra ID Tenant ID to use for retrieving Access Token for Authorization header")]
+    [CommandOption("--azure-tenant-id <TENANT-ID>")]
+    public string? AzureTenantId { get; set; }
+    
+    [Description("Azure Entra ID Scope to use for retrieving Access Token for Authorization header")]
+    [CommandOption("--azure-scope <SCOPE>")]
+    public string? AzureScope { get; set; }
 }

--- a/src/HttpGenerator/Settings.cs
+++ b/src/HttpGenerator/Settings.cs
@@ -49,11 +49,11 @@ public class Settings : CommandSettings
     [AllowedValues(nameof(OutputType.OneRequestPerFile), nameof(OutputType.OneFile))]
     public OutputType OutputType { get; set; } = OutputType.OneRequestPerFile;
     
-    [Description("Azure Entra ID Tenant ID to use for retrieving Access Token for Authorization header")]
-    [CommandOption("--azure-tenant-id <TENANT-ID>")]
-    public string? AzureTenantId { get; set; }
-    
     [Description("Azure Entra ID Scope to use for retrieving Access Token for Authorization header")]
     [CommandOption("--azure-scope <SCOPE>")]
     public string? AzureScope { get; set; }
+    
+    [Description("Azure Entra ID Tenant ID to use for retrieving Access Token for Authorization header")]
+    [CommandOption("--azure-tenant-id <TENANT-ID>")]
+    public string? AzureTenantId { get; set; }
 }


### PR DESCRIPTION
The changes here add the `--azure-scope` and `--azure-tenant` arguments to the CLI tool. The `--azure-scope` and `azure-tenant-id` arguments internally use `DefaultAzureCredentials` from the `Microsoft.Extensions.Azure` NuGet package to retrieve an access token for the specified `scope`.

```powershell
httpgenerator `
  https://api.example.com/swagger/v1/swagger.json `
  --azure-tenant-id [Some Azure Tenant ID] `
  --azure-scope [Some Application ID URI]/.default `
  --base-url https://api.example.com `
  --output ./HttpFiles 
```