### PR TITLE
Update build command to disable extension deployment

### DIFF
--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.3
     - name: Build
-      run: msbuild VSIX.sln /property:Configuration=Release /t:Rebuild
+      run: msbuild VSIX.sln /property:Configuration=Release /p:DeployExtension=false
       working-directory: src
     - name: Move build output
       run: |

--- a/.github/workflows/vsix.yml
+++ b/.github/workflows/vsix.yml
@@ -40,7 +40,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1.3
 
     - name: Build
-      run: msbuild VSIX.sln /property:Configuration=Release /t:Rebuild
+      run: msbuild VSIX.sln /property:Configuration=Release /p:DeployExtension=false
       working-directory: src
 
     - name: Move build output


### PR DESCRIPTION
This pull request updates the build command in the VSIX.sln file to disable extension deployment. Previously, the command would deploy the extension, but now it has been modified to not deploy the extension. This change ensures that the build process does not include the extension deployment step.