### PR TITLE
Add support for loading authorization header from environment variable

### DIFF
--- a/src/HttpGenerator.Core/GeneratorSettings.cs
+++ b/src/HttpGenerator.Core/GeneratorSettings.cs
@@ -17,6 +17,17 @@ public class GeneratorSettings
     /// Gets or sets the authorization header to use for all requests
     /// </summary>
     public string? AuthorizationHeader { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether to load the authorization header
+    /// from an environment variable or define it in the .http file
+    /// </summary>
+    public bool AuthorizationHeaderFromEnvironmentVariable { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the environment variable to load the authorization header from
+    /// </summary>
+    public string AuthorizationHeaderVariableName { get; set; } = "authorization";
     
     /// <summary>
     /// Gets or sets the default Content-Type header to use for all requests

--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -57,9 +57,10 @@ public static class HttpFileGenerator
     {
         code.AppendLine($"@contentType = {settings.ContentType}");
 
-        if (!string.IsNullOrWhiteSpace(settings.AuthorizationHeader))
+        if (!string.IsNullOrWhiteSpace(settings.AuthorizationHeader) && 
+            !settings.AuthorizationHeaderFromEnvironmentVariable)
         {
-            code.AppendLine($"@authorization = {settings.AuthorizationHeader}");
+            code.AppendLine($"@{settings.AuthorizationHeaderVariableName} = {settings.AuthorizationHeader}");
         }
 
         code.AppendLine();
@@ -110,9 +111,10 @@ public static class HttpFileGenerator
         code.AppendLine($"{verb.ToUpperInvariant()} {baseUrl}{url}");
         code.AppendLine("Content-Type: {{contentType}}");
 
-        if (!string.IsNullOrWhiteSpace(settings.AuthorizationHeader))
+        if (!string.IsNullOrWhiteSpace(settings.AuthorizationHeader) ||
+            settings.AuthorizationHeaderFromEnvironmentVariable)
         {
-            code.AppendLine("Authorization: {{authorization}}");
+            code.AppendLine($"Authorization: {{{{{settings.AuthorizationHeaderVariableName}}}}}");
         }
 
         var contentType = operation.RequestBody?.Content?.Keys

--- a/src/HttpGenerator/GenerateCommand.cs
+++ b/src/HttpGenerator/GenerateCommand.cs
@@ -35,6 +35,8 @@ public class GenerateCommand : AsyncCommand<Settings>
             var generatorSettings = new GeneratorSettings
             {
                 AuthorizationHeader = settings.AuthorizationHeader,
+                AuthorizationHeaderVariableName = settings.AuthorizationHeaderVariableName,
+                AuthorizationHeaderFromEnvironmentVariable = settings.AuthorizationHeaderFromEnvironmentVariable,
                 OpenApiPath = settings.OpenApiPath,
                 ContentType = settings.ContentType,
                 BaseUrl = settings.BaseUrl,

--- a/src/HttpGenerator/Settings.cs
+++ b/src/HttpGenerator/Settings.cs
@@ -31,6 +31,16 @@ public class Settings : CommandSettings
     [Description("Authorization header to use for all requests")]
     [CommandOption("--authorization-header <HEADER>")]
     public string? AuthorizationHeader { get; set; }
+
+    [Description("Load the authorization header from an environment variable or define it in the .http file. " +
+                 "You can use --authorization-header-variable-name to specify the environment variable name.")]
+    [CommandOption("--load-authorization-header-from-environment")]
+    public bool AuthorizationHeaderFromEnvironmentVariable { get; set; }
+
+    [Description("Name of the environment variable to load the authorization header from")]
+    [CommandOption("--authorization-header-variable-name <VARIABLE-NAME>")]
+    [DefaultValue("authorization")]
+    public string AuthorizationHeaderVariableName { get; set; } = "authorization";
     
     [Description("Default Content-Type header to use for all requests")]
     [CommandOption("--content-type <CONTENT-TYPE>")]


### PR DESCRIPTION
This pull request adds support for loading the authorization header from an environment variable instead of defining it in the .http file. It includes updates to the GeneratorSettings, HttpFileGenerator, GenerateCommand, and Settings files to handle this functionality.

This implements #51

With these changes, the following command

```sh
httpgenerator https://petstore3.swagger.io/api/v3/openapi.json --base-url https://petstore3.swagger.io --load-authorization-header-from-environment
```

produces an output of something like this:

```
@contentType = application/json

###############################################
### Request: PUT /pet
### Summary: Update an existing pet
### Description: Update an existing pet by Id
###############################################


PUT https://petstore3.swagger.io/api/v3/pet
Content-Type: {{contentType}}
Authorization: {{authorization}}

{
  "id": 0,
  "name": "name",
  "category": {
    "id": 0,
    "name": "name"
  },
  "photoUrls": [
    ""
  ],
  "tags": [
    {
      "id": 0,
      "name": "name"
    }
  ],
  "status": "available"
}
```

It's up to the user to create the `env.json` file. You can customize the variable name to use for the Authorization header by specifying the `--authorization-header-variable-name` option, the default is `authorization`

The env.json looks something like this:

```json
{
  "Dev": {
    "authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
  }
}
```

and from Jetbrains Rider it behaves like this:

![image](https://github.com/christianhelle/httpgenerator/assets/710400/1ff287c4-921e-45c1-b106-117cabebf0b8)

which when run will send the following request:

```
PUT https://petstore3.swagger.io/api/v3/pet
Content-Type: application/json
Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
Content-Length: 203
Connection: Keep-Alive
User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.9)
Accept-Encoding: br,deflate,gzip,x-gzip

{
  "id": 0,
  "name": "name",
  "category": {
    "id": 0,
    "name": "name"
  },
  "photoUrls": [
    ""
  ],
  "tags": [
    {
      "id": 0,
      "name": "name"
    }
  ],
  "status": "available"
}
```
