### PR TITLE
Update StringExtensions.cs

### DIFF
--- a/src/HttpGenerator.Core/StringExtensions.cs
+++ b/src/HttpGenerator.Core/StringExtensions.cs
@@ -4,7 +4,7 @@ public static class StringExtensions
 {
     public static string ConvertKebabCaseToPascalCase(this string str)
     {
-        var parts = str.Split('-');
+        var parts = str.Split(['-'], StringSplitOptions.RemoveEmptyEntries);
 
         for (var i = 0; i < parts.Length; i++)
         {
@@ -16,7 +16,8 @@ public static class StringExtensions
 
     public static string ConvertRouteToCamelCase(this string str)
     {
-        var parts = str.Split('/');
+        var parts = str.Split(['/'], StringSplitOptions.RemoveEmptyEntries);
+        
         for (var i = 1; i < parts.Length; i++)
         {
             parts[i] = parts[i].CapitalizeFirstCharacter();
@@ -33,7 +34,8 @@ public static class StringExtensions
 
     public static string ConvertSpacesToPascalCase(this string str)
     {
-        var parts = str.Split(' ');
+        var parts = str.Split([' '], StringSplitOptions.RemoveEmptyEntries);
+        
         for (var i = 0; i < parts.Length; i++)
         {
             parts[i] = parts[i].CapitalizeFirstCharacter();


### PR DESCRIPTION
Use the `StringSplitOptions.RemoveEmptyEntries` option when splitting a string to avoid `ArgumentOutOfRangeException` being raised when the `Substring` operation is attempted on an empty string.

```
Error:
Index and length must refer to a location within the string. (Parameter 'length')
Exception:
System.ArgumentOutOfRangeException
Stack Trace:
   at System.String.ThrowSubstringArgumentOutOfRange(Int32 startIndex, Int32 length)
   at System.String.Substring(Int32 startIndex, Int32 length)
   at HttpGenerator.Core.StringExtensions.CapitalizeFirstCharacter(String str) in /_/src/HttpGenerator.Core/StringExtensions.cs:line 30
   at HttpGenerator.Core.StringExtensions.ConvertRouteToCamelCase(String str) in /_/src/HttpGenerator.Core/StringExtensions.cs:line 22
   at HttpGenerator.Core.OperationNameGenerator.GetOperationName(OpenApiDocument document, String path, String httpMethod, OpenApiOperation operation) in /_/src/HttpGenerator.Core/OperationNameGenerator.cs:line 44
   at HttpGenerator.Core.HttpFileGenerator.GenerateMultipleFiles(GeneratorSettings settings, OpenApiDocument document, String baseUrl, IOperationNameGenerator operationNameGenerator) in 
/_/src/HttpGenerator.Core/HttpFileGenerator.cs:line 87
   at HttpGenerator.Core.HttpFileGenerator.Generate(GeneratorSettings settings) in /_/src/HttpGenerator.Core/HttpFileGenerator.cs:line 27
   at HttpGenerator.GenerateCommand.ExecuteAsync(CommandContext context, Settings settings) in /_/src/HttpGenerator/GenerateCommand.cs:line 46
   ```