### PR TITLE
Use Console.WriteLine if AnsiConsole.MarkupLine fails

### DIFF
--- a/src/HttpGenerator/GenerateCommand.cs
+++ b/src/HttpGenerator/GenerateCommand.cs
@@ -150,7 +150,17 @@ public class GenerateCommand : AsyncCommand<Settings>
         }
         catch
         {
-            // ignored
+            var originalColor = Console.ForegroundColor;
+            Console.ForegroundColor = color switch
+            {
+                "red" => ConsoleColor.Red,
+                "yellow" => ConsoleColor.Yellow,
+                _ => originalColor
+            };
+
+            Console.WriteLine($"{label}:{Crlf}{error}{Crlf}");
+
+            Console.ForegroundColor = originalColor;
         }
     }
 }


### PR DESCRIPTION
Updated the error handling within the `GenerateCommand` class in `GenerateCommand.cs`.

The changes include modifying the console's foreground color based on the `color` variable's value to enhance the visibility of error messages. The console's color changes to red or yellow depending on the severity of the error, and the error message is printed to the console. The console's foreground color is then reset to its original color. This update ensures that exceptions are no longer ignored and are instead highlighted effectively.

This should resolve #78 