### PR TITLE
Generate file per tag

### DIFF
--- a/src/HttpGenerator.Core/GeneratorSettings.cs
+++ b/src/HttpGenerator.Core/GeneratorSettings.cs
@@ -64,4 +64,9 @@ public enum OutputType
     /// Generate a single .http file for all requests
     /// </summary>
     OneFile,
+
+    /// <summary>
+    /// Generate one .http file per first tag associated with each request
+    /// </summary>
+    OneFilePerTag,
 }

--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -148,7 +148,9 @@ public static class HttpFileGenerator
             }
         }
 
-        var files = contents.Select(x => new HttpFile($"{x.Key}.http", x.Value.ToString())).ToList();
+        var files = contents
+            .Select(x => new HttpFile($"{x.Key.CapitalizeFirstCharacter()}.http", x.Value.ToString()))
+            .ToList();
         return new GeneratorResult(files);
     }
 

--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -27,7 +27,7 @@ public static class HttpFileGenerator
                 OutputType.OneRequestPerFile => GenerateMultipleFiles(settings, document, baseUrl, generator.BaseSettings.OperationNameGenerator),
                 OutputType.OneFile => GenerateSingleFile(settings, document, generator.BaseSettings.OperationNameGenerator, baseUrl),
                 OutputType.OneFilePerTag => GenerateFilePerTag(settings, document, baseUrl, generator.BaseSettings.OperationNameGenerator),
-                _ => throw new ArgumentOutOfRangeException()
+                _ => throw new ArgumentOutOfRangeException(nameof(settings.OutputType), $"Unknown output type: {settings.OutputType}")
             };
         }
 
@@ -44,7 +44,7 @@ public static class HttpFileGenerator
             OutputType.OneRequestPerFile => GenerateMultipleFiles(settings, document, baseUrl, generator.BaseSettings.OperationNameGenerator),
             OutputType.OneFile => GenerateSingleFile(settings, document, generator.BaseSettings.OperationNameGenerator, baseUrl),
             OutputType.OneFilePerTag => GenerateFilePerTag(settings, document, baseUrl, generator.BaseSettings.OperationNameGenerator),
-            _ => throw new ArgumentOutOfRangeException()
+            _ => throw new ArgumentOutOfRangeException(nameof(settings.OutputType), $"Unknown output type: {settings.OutputType}")
         };
     }
 

--- a/src/HttpGenerator.Tests/SwaggerPetstoreTests.cs
+++ b/src/HttpGenerator.Tests/SwaggerPetstoreTests.cs
@@ -55,6 +55,10 @@ public class SwaggerPetstoreTests
     [InlineData(HttpsUrlPrefix + "petstore.yaml", OutputType.OneFile)]
     [InlineData(HttpUrlPrefix + "petstore.json", OutputType.OneFile)]
     [InlineData(HttpUrlPrefix + "petstore.yaml", OutputType.OneFile)]
+    [InlineData(HttpsUrlPrefix + "petstore.json", OutputType.OneFilePerTag)]
+    [InlineData(HttpsUrlPrefix + "petstore.yaml", OutputType.OneFilePerTag)]
+    [InlineData(HttpUrlPrefix + "petstore.json", OutputType.OneFilePerTag)]
+    [InlineData(HttpUrlPrefix + "petstore.yaml", OutputType.OneFilePerTag)]
     public async Task Can_Generate_Code_From_Url(string url, OutputType outputType)
     {
         var generateCode = await HttpFileGenerator.Generate(
@@ -83,6 +87,10 @@ public class SwaggerPetstoreTests
     [InlineData(HttpsUrlPrefix + "petstore.yaml", OutputType.OneFile)]
     [InlineData(HttpUrlPrefix + "petstore.json", OutputType.OneFile)]
     [InlineData(HttpUrlPrefix + "petstore.yaml", OutputType.OneFile)]
+    [InlineData(HttpsUrlPrefix + "petstore.json", OutputType.OneFilePerTag)]
+    [InlineData(HttpsUrlPrefix + "petstore.yaml", OutputType.OneFilePerTag)]
+    [InlineData(HttpUrlPrefix + "petstore.json", OutputType.OneFilePerTag)]
+    [InlineData(HttpUrlPrefix + "petstore.yaml", OutputType.OneFilePerTag)]
     public async Task Files_Generated_From_Url_Uses_OpenApiPath_Authority_As_For_BaseUrl(
         string url,
         OutputType outputType)


### PR DESCRIPTION
This PR is related to feature request #97 
Added support to generate file per operation tag.
This implementation is not particularly efficient, as it will store partial result in `StringBuilder` for each file in memory, but it shouldn't cause much impact than building single file.

OpenAPI allows to specify more than one tag per operation and Swagger UI will show the same request under multiple categories. But this implementation will look only for the first tag (this will be a controller name in case of default MVC Core configuration).