### PR TITLE
Include query string parameters on URL

### DIFF
--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -176,9 +176,24 @@ public static class HttpFileGenerator
             code);
 
         var url = operationPath.Key.Replace("{", "{{").Replace("}", "}}");
-        foreach (var parameterName in parameterNameMap)
+        if (url.Contains("{") || url.Contains("}"))
         {
-            url = url.Replace($"{{{parameterName.Key}}}", $"{{{parameterName.Value}}}");
+            foreach (var parameterName in parameterNameMap)
+            {
+                url = url.Replace($"{{{{{parameterName.Key}}}}}", $"{{{{{parameterName.Value}}}}}");
+            }
+        }
+        else
+        {
+            if (parameterNameMap.Count>0)
+            {
+                url += "?";
+            }
+
+            foreach (var parameterName in parameterNameMap)
+            {
+                url += $"{parameterName.Key}={{{{{parameterName.Key}}}}}&";
+            }
         }
 
         code.AppendLine($"{verb.ToUpperInvariant()} {baseUrl}{url}");

--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -192,7 +192,7 @@ public static class HttpFileGenerator
 
             foreach (var parameterName in parameterNameMap)
             {
-                url += $"{parameterName.Key}={{{{{parameterName.Key}}}}}&";
+                url += $"{parameterName.Key}={{{{{parameterName.Value}}}}}&";
             }
         }
 

--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -194,6 +194,8 @@ public static class HttpFileGenerator
             {
                 url += $"{parameterName.Key}={{{{{parameterName.Value}}}}}&";
             }
+            
+            url = url.Remove(url.Length - 1);
         }
 
         code.AppendLine($"{verb.ToUpperInvariant()} {baseUrl}{url}");

--- a/src/HttpGenerator.Tests/GenerateCommandTests.cs
+++ b/src/HttpGenerator.Tests/GenerateCommandTests.cs
@@ -18,26 +18,25 @@ public class GenerateCommandTests
         Http + "://raw.githubusercontent.com/christianhelle/httpgenerator/main/test/OpenAPI/v3.0/";
 
     [Theory]
-    [Inline(Samples.PetstoreJsonV3, "SwaggerPetstore.json", OutputType.OneRequestPerFile)]
-    [Inline(Samples.PetstoreYamlV3, "SwaggerPetstore.yaml", OutputType.OneRequestPerFile)]
-    [Inline(Samples.PetstoreJsonV2, "SwaggerPetstore.json", OutputType.OneRequestPerFile)]
-    [Inline(Samples.PetstoreYamlV2, "SwaggerPetstore.yaml", OutputType.OneRequestPerFile)]
-    [Inline(Samples.PetstoreJsonV3, "SwaggerPetstore.json", OutputType.OneFile)]
-    [Inline(Samples.PetstoreYamlV3, "SwaggerPetstore.yaml", OutputType.OneFile)]
-    [Inline(Samples.PetstoreJsonV2, "SwaggerPetstore.json", OutputType.OneFile)]
-    [Inline(Samples.PetstoreYamlV2, "SwaggerPetstore.yaml", OutputType.OneFile)]
-    [Inline(Samples.PetstoreJsonV3WithDifferentHeaders, "SwaggerPetstore.json", OutputType.OneRequestPerFile)]
-    [Inline(Samples.PetstoreYamlV3WithDifferentHeaders, "SwaggerPetstore.yaml", OutputType.OneRequestPerFile)]
-    [Inline(Samples.PetstoreJsonV2WithDifferentHeaders, "SwaggerPetstore.json", OutputType.OneRequestPerFile)]
-    [Inline(Samples.PetstoreYamlV2WithDifferentHeaders, "SwaggerPetstore.yaml", OutputType.OneRequestPerFile)]
-    [Inline(Samples.PetstoreJsonV3WithDifferentHeaders, "SwaggerPetstore.json", OutputType.OneFile)]
-    [Inline(Samples.PetstoreYamlV3WithDifferentHeaders, "SwaggerPetstore.yaml", OutputType.OneFile)]
-    [Inline(Samples.PetstoreJsonV2WithDifferentHeaders, "SwaggerPetstore.json", OutputType.OneFile)]
-    [Inline(Samples.PetstoreYamlV2WithDifferentHeaders, "SwaggerPetstore.yaml", OutputType.OneFile)]
+    [Inline(Samples.PetstoreJsonV3, "SwaggerPetstore.json")]
+    [Inline(Samples.PetstoreYamlV3, "SwaggerPetstore.yaml")]
+    [Inline(Samples.PetstoreJsonV2, "SwaggerPetstore.json")]
+    [Inline(Samples.PetstoreYamlV2, "SwaggerPetstore.yaml")]
+    [Inline(Samples.PetstoreJsonV3, "SwaggerPetstore.json")]
+    [Inline(Samples.PetstoreYamlV3, "SwaggerPetstore.yaml")]
+    [Inline(Samples.PetstoreJsonV2, "SwaggerPetstore.json")]
+    [Inline(Samples.PetstoreYamlV2, "SwaggerPetstore.yaml")]
+    [Inline(Samples.PetstoreJsonV3WithDifferentHeaders, "SwaggerPetstore.json")]
+    [Inline(Samples.PetstoreYamlV3WithDifferentHeaders, "SwaggerPetstore.yaml")]
+    [Inline(Samples.PetstoreJsonV2WithDifferentHeaders, "SwaggerPetstore.json")]
+    [Inline(Samples.PetstoreYamlV2WithDifferentHeaders, "SwaggerPetstore.yaml")]
+    [Inline(Samples.PetstoreJsonV3WithDifferentHeaders, "SwaggerPetstore.json")]
+    [Inline(Samples.PetstoreYamlV3WithDifferentHeaders, "SwaggerPetstore.yaml")]
+    [Inline(Samples.PetstoreJsonV2WithDifferentHeaders, "SwaggerPetstore.json")]
+    [Inline(Samples.PetstoreYamlV2WithDifferentHeaders, "SwaggerPetstore.yaml")]
     public async Task Should_Generate_Code_From_File(
         Samples version,
         string filename,
-        OutputType outputType,
         GenerateCommand sut,
         CommandContext context,
         Settings settings)

--- a/src/HttpGenerator.Tests/HttpGenerator.Tests.csproj
+++ b/src/HttpGenerator.Tests/HttpGenerator.Tests.csproj
@@ -35,14 +35,11 @@
     <EmbeddedResource Include="Resources\V3\SwaggerPetstoreWithDifferentHeaders.yaml" />
     <EmbeddedResource Include="Resources\V3\SwaggerPetstoreWithMultlineDescriptions.json" />
     <EmbeddedResource Include="Resources\V3\SwaggerPetstoreWithMultlineDescriptions.yaml" />
-    <None Remove="Resources\V31\non-oauth-scopes.json" />
     <EmbeddedResource Include="Resources\V31\non-oauth-scopes.json" />
-    <None Remove="Resources\V31\non-oauth-scopes.yaml" />
     <EmbeddedResource Include="Resources\V31\non-oauth-scopes.yaml" />
-    <None Remove="Resources\V31\webhook-example.json" />
     <EmbeddedResource Include="Resources\V31\webhook-example.json" />
-    <None Remove="Resources\V31\webhook-example.yaml" />
     <EmbeddedResource Include="Resources\V31\webhook-example.yaml" />
+    <None Remove="README.md" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HttpGenerator.Tests/SwaggerPetstoreTests.cs
+++ b/src/HttpGenerator.Tests/SwaggerPetstoreTests.cs
@@ -133,6 +133,27 @@ public class SwaggerPetstoreTests
             .BeTrue();
     }
 
+    [Theory]
+    [InlineData(Samples.PetstoreJsonV2, "SwaggerPetstore.json", OutputType.OneFile)]
+    [InlineData(Samples.PetstoreYamlV2, "SwaggerPetstore.yaml", OutputType.OneFile)]
+    [InlineData(Samples.PetstoreJsonV3, "SwaggerPetstore.json", OutputType.OneFile)]
+    [InlineData(Samples.PetstoreYamlV3, "SwaggerPetstore.yaml", OutputType.OneFile)]
+    public async Task Can_Generate_Code_With_Query_String_Parameters(
+        Samples version,
+        string filename,
+        OutputType outputType)
+    {
+        var generateCode = await GenerateCode(version, filename, outputType);
+
+        using var scope = new AssertionScope();
+        generateCode.Should().NotBeNull();
+        generateCode.Files.Should().NotBeNullOrEmpty();
+        generateCode.Files
+            .Any(file => file.Content.Contains("?status={{") && file.Content.Contains("}}"))
+            .Should()
+            .BeTrue();
+    }
+
     private static async Task<GeneratorResult> GenerateCode(
         Samples version,
         string filename,


### PR DESCRIPTION
This pull request fixes an issue where query string parameters were missing from the URL. 

The code now correctly includes the query string parameters in the URL when necessary.

The following specifications:

```yaml
  /pet/findByStatus:
    get:
      tags:
        - pet
      summary: Finds Pets by status
      description: Multiple status values can be provided with comma separated strings
      operationId: findPetsByStatus
      parameters:
        - name: status
          in: query
          description: Status values that need to be considered for filter
          required: false
          explode: true
          schema:
            type: string
            default: available
            enum:
              - available
              - pending
              - sold
```

now generates

```
@contentType = application/json

######################################################################################
### Request: GET /pet/findByStatus
### Summary: Finds Pets by status
### Description: Multiple status values can be provided with comma separated strings
######################################################################################

### Query Parameter: Status values that need to be considered for filter
@status = str


GET /api/v3/pet/findByStatus?status={{status}}
Content-Type: {{contentType}}
```