### PR TITLE
Use Azure Application Insights for Telemetry data

### DIFF
--- a/src/HttpGenerator/HttpGenerator.csproj
+++ b/src/HttpGenerator/HttpGenerator.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="Exceptionless" Version="6.0.4" />
+        <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.22.0" />
         <PackageReference Include="Microsoft.OpenApi.OData" Version="1.6.8" />
         <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.21" />
         <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />

--- a/src/HttpGenerator/SupportKeyInitializer.cs
+++ b/src/HttpGenerator/SupportKeyInitializer.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace HttpGenerator;
+
+public sealed class SupportKeyInitializer : ITelemetryInitializer
+{
+    public void Initialize(ITelemetry telemetry)
+    {
+        if (telemetry is ISupportProperties supportProperties)
+            supportProperties.Properties["support-key"] = SupportInformation.GetSupportKey();
+    }
+}


### PR DESCRIPTION
This pull request introduces Application Insights telemetry to the `HttpGenerator` project for enhanced logging and monitoring. The main changes include integrating Application Insights, updating the `Analytics` class, and adding a telemetry initializer.

### Integration of Application Insights:

* [`src/HttpGenerator/HttpGenerator.csproj`](diffhunk://#diff-7407c5d153da68c12ce72982272e70ec7a301f75ee0fa792383399134f99de7bR17): Added `Microsoft.ApplicationInsights.WindowsServer` package reference to include Application Insights in the project.

### Updates to `Analytics` class:

* `src/HttpGenerator/Analytics.cs`: 
  - Added `TelemetryClient` initialization and configuration in the `Configure` method.
  - Refactored `LogFeatureUsage` method to use a new helper method and log events with Application Insights.
  - Updated `LogError` method to log exceptions with Application Insights and include serialized settings.

### Addition of telemetry initializer:

* [`src/HttpGenerator/SupportKeyInitializer.cs`](diffhunk://#diff-82976d2a8c4302873c9d79005ac3dacfb8357119e4bba194584b252b3c1830fdR1-R14): Created `SupportKeyInitializer` class to add a custom property (`support-key`) to all telemetry data.