### PR TITLE
Fix missing last character in URL

### DIFF
--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -194,8 +194,11 @@ public static class HttpFileGenerator
             {
                 url += $"{parameterName.Key}={{{{{parameterName.Value}}}}}&";
             }
-            
-            url = url.Remove(url.Length - 1);
+
+            if (parameterNameMap.Count > 0)
+            {
+                url = url.Remove(url.Length - 1);
+            }
         }
 
         code.AppendLine($"{verb.ToUpperInvariant()} {baseUrl}{url}");

--- a/src/HttpGenerator.Core/HttpGenerator.Core.csproj
+++ b/src/HttpGenerator.Core/HttpGenerator.Core.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="NSwag.CodeGeneration.CSharp" Version="14.1.0" />
     <PackageReference Include="NSwag.Core.Yaml" Version="14.1.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.5" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request includes enhancements to the URL generation logic in `HttpFileGenerator.cs` and an update to the project dependencies in `HttpGenerator.Core.csproj`.

Improvements to URL generation logic:

* [`src/HttpGenerator.Core/HttpFileGenerator.cs`](diffhunk://#diff-6f6546de68ac0c0b21869ca2be5fe01ad04dbd88b52267f3eeb40c2df29dd4d9R198-R202): Added a check to ensure the URL is only modified when `parameterNameMap` contains elements, preventing potential errors.

Project dependencies update:

* [`src/HttpGenerator.Core/HttpGenerator.Core.csproj`](diffhunk://#diff-5a09dae2dea445cc972f5a97958ab82dd0fc3d2c144ba589c27245db7e43402bR20): Added a new package reference for `System.Text.Json` version `8.0.4` to the project dependencies.