### PR TITLE
Add support for generating Custom Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,29 +32,38 @@ EXAMPLES:
     httpgenerator ./openapi.json --output-type onefile
     httpgenerator https://petstore.swagger.io/v2/swagger.json
     httpgenerator https://petstore3.swagger.io/api/v3/openapi.json --base-url https://petstore3.swagger.io
-    httpgenerator ./openapi.json --authorization-header Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+    httpgenerator ./openapi.json --authorization-header Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9c
     httpgenerator ./openapi.json --azure-scope [Some Application ID URI]/.default
+    httpgenerator ./openapi.json --generate-intellij-tests
+    httpgenerator ./openapi.json --custom-header X-Custom-Header: Value --custom-header X-Another-Header: AnotherValue
 
 ARGUMENTS:
     [URL or input file]    URL or file path to OpenAPI Specification file
 
 OPTIONS:
-                                                                DEFAULT                                                                                                                                                                                                               
-    -h, --help                                                                       Prints help information                                                                                                                                                                          
-    -v, --version                                                                    Prints version information                                                                                                                                                                       
-    -o, --output <OUTPUT>                                       ./                   Output directory                                                                                                                                                                                 
-        --no-logging                                                                 Don't log errors or collect telemetry                                                                                                                                                            
-        --skip-validation                                                            Skip validation of OpenAPI Specification file                                                                                                                                                    
-        --authorization-header <HEADER>                                              Authorization header to use for all requests                                                                                                                                                     
-        --load-authorization-header-from-environment                                 Load the authorization header from an environment variable or define it in the .http file. You can use --authorization-header-variable-name to specify the environment variable name             
-        --authorization-header-variable-name <VARIABLE-NAME>    authorization        Name of the environment variable to load the authorization header from                                                                                                                           
-        --content-type <CONTENT-TYPE>                           application/json     Default Content-Type header to use for all requests                                                                                                                                              
-        --base-url <BASE-URL>                                                        Default Base URL to use for all requests. Use this if the OpenAPI spec doesn't explicitly specify a server URL                                                                                   
-        --output-type <OUTPUT-TYPE>                             OneRequestPerFile    OneRequestPerFile generates one .http file per request. OneFile generates a single .http file for all requests. OneFilePerTag generates one .http file per first tag associated with each request
-        --azure-scope <SCOPE>                                                        Azure Entra ID Scope to use for retrieving Access Token for Authorization header                                                                                                                 
-        --azure-tenant-id <TENANT-ID>                                                Azure Entra ID Tenant ID to use for retrieving Access Token for Authorization header                                                                                                             
-        --timeout <SECONDS>                                     120                  Timeout (in seconds) for writing files to disk                                                                                                                                                   
-        --generate-intellij-tests                                                    Generate IntelliJ tests that assert whether the response status code is 200                                                                                                                      
+                                                                DEFAULT
+    -h, --help                                                                       Prints help information
+    -v, --version                                                                    Prints version information
+    -o, --output <OUTPUT>                                       ./                   Output directory
+        --no-logging                                                                 Don't log errors or collect telemetry
+        --skip-validation                                                            Skip validation of OpenAPI Specification file
+        --authorization-header <HEADER>                                              Authorization header to use for all requests
+        --load-authorization-header-from-environment                                 Load the authorization header from an environment variable or define it in the
+                                                                                     .http file. You can use --authorization-header-variable-name to specify the
+                                                                                     environment variable name
+        --authorization-header-variable-name <VARIABLE-NAME>    authorization        Name of the environment variable to load the authorization header from
+        --content-type <CONTENT-TYPE>                           application/json     Default Content-Type header to use for all requests
+        --base-url <BASE-URL>                                                        Default Base URL to use for all requests. Use this if the OpenAPI spec doesn't
+                                                                                     explicitly specify a server URL
+        --output-type <OUTPUT-TYPE>                             OneRequestPerFile    OneRequestPerFile generates one .http file per request. OneFile generates a
+                                                                                     single .http file for all requests. OneFilePerTag generates one .http file per
+                                                                                     first tag associated with each request
+        --azure-scope <SCOPE>                                                        Azure Entra ID Scope to use for retrieving Access Token for Authorization header
+        --azure-tenant-id <TENANT-ID>                                                Azure Entra ID Tenant ID to use for retrieving Access Token for Authorization
+                                                                                     header
+        --timeout <SECONDS>                                     120                  Timeout (in seconds) for writing files to disk
+        --generate-intellij-tests                                                    Generate IntelliJ tests that assert whether the response status code is 200
+        --custom-header                                                              Add custom HTTP headers to the generated request
 ```
 
 Running the following:

--- a/src/HttpGenerator.Core/GeneratorSettings.cs
+++ b/src/HttpGenerator.Core/GeneratorSettings.cs
@@ -53,6 +53,11 @@ public class GeneratorSettings
     /// Gets or sets whether to generate IntelliJ tests
     /// </summary>
     public bool GenerateIntelliJTests { get; set; }
+
+    /// <summary>
+    /// Gets or sets custom HTTP headers to add to the generated request
+    /// </summary>
+    public string[]? CustomHeaders { get; set; }
 }
 
 /// <summary>

--- a/src/HttpGenerator.Core/GeneratorSettings.cs
+++ b/src/HttpGenerator.Core/GeneratorSettings.cs
@@ -12,7 +12,7 @@ public class GeneratorSettings
     /// Gets or sets the path to the Open API (local file or URL)
     /// </summary>
     public string OpenApiPath { get; set; } = null!;
-    
+
     /// <summary>
     /// Gets or sets the authorization header to use for all requests
     /// </summary>
@@ -28,7 +28,7 @@ public class GeneratorSettings
     /// Gets or sets the name of the environment variable to load the authorization header from
     /// </summary>
     public string AuthorizationHeaderVariableName { get; set; } = "authorization";
-    
+
     /// <summary>
     /// Gets or sets the default Content-Type header to use for all requests
     /// </summary>
@@ -40,10 +40,10 @@ public class GeneratorSettings
     public string? BaseUrl { get; set; }
 
     /// <summary>
-    /// Gets or sets the default output type for the generated .http files 
+    /// Gets or sets the default output type for the generated .http files
     /// </summary>
     public OutputType OutputType { get; set; }
-    
+
     /// <summary>
     /// Gets or sets the timeout (in seconds) for writing files to disk
     /// </summary>
@@ -69,7 +69,7 @@ public enum OutputType
     /// Generate one .http file per request
     /// </summary>
     OneRequestPerFile,
-    
+
     /// <summary>
     /// Generate a single .http file for all requests
     /// </summary>
@@ -80,3 +80,4 @@ public enum OutputType
     /// </summary>
     OneFilePerTag,
 }
+

--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -209,6 +209,14 @@ public static class HttpFileGenerator
             code.AppendLine($"Authorization: {{{{{settings.AuthorizationHeaderVariableName}}}}}");
         }
 
+        if (settings.CustomHeaders is not null)
+        {
+            foreach (var customHeader in settings.CustomHeaders)
+            {
+                code.AppendLine(customHeader);
+            }
+        }
+
         var contentType = operation.RequestBody?.Content?.Keys
             ?.FirstOrDefault(c => c.Contains(settings.ContentType));
 

--- a/src/HttpGenerator/GenerateCommand.cs
+++ b/src/HttpGenerator/GenerateCommand.cs
@@ -42,6 +42,7 @@ public class GenerateCommand : AsyncCommand<Settings>
                 OutputType = settings.OutputType,
                 Timeout = settings.Timeout,
                 GenerateIntelliJTests = settings.GenerateIntelliJTests,
+                CustomHeaders = settings.CustomHeaders,
             };
 
             var result = await HttpFileGenerator.Generate(generatorSettings);

--- a/src/HttpGenerator/Program.cs
+++ b/src/HttpGenerator/Program.cs
@@ -70,6 +70,14 @@ internal static class Program
                         InputFilename,
                         "--generate-intellij-tests");
 
+                configuration
+                    .AddExample(
+                        InputFilename,
+                        "--custom-header",
+                        "X-Custom-Header: Value",
+                        "--custom-header",
+                        "X-Another-Header: AnotherValue");
+
             });
 
         return app.Run(args);

--- a/src/HttpGenerator/README.md
+++ b/src/HttpGenerator/README.md
@@ -16,29 +16,38 @@ EXAMPLES:
     httpgenerator ./openapi.json --output-type onefile
     httpgenerator https://petstore.swagger.io/v2/swagger.json
     httpgenerator https://petstore3.swagger.io/api/v3/openapi.json --base-url https://petstore3.swagger.io
-    httpgenerator ./openapi.json --authorization-header Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+    httpgenerator ./openapi.json --authorization-header Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9c
     httpgenerator ./openapi.json --azure-scope [Some Application ID URI]/.default
+    httpgenerator ./openapi.json --generate-intellij-tests
+    httpgenerator ./openapi.json --custom-header X-Custom-Header: Value --custom-header X-Another-Header: AnotherValue
 
 ARGUMENTS:
     [URL or input file]    URL or file path to OpenAPI Specification file
 
 OPTIONS:
-                                                                DEFAULT                                                                                                                                                                                                               
-    -h, --help                                                                       Prints help information                                                                                                                                                                          
-    -v, --version                                                                    Prints version information                                                                                                                                                                       
-    -o, --output <OUTPUT>                                       ./                   Output directory                                                                                                                                                                                 
-        --no-logging                                                                 Don't log errors or collect telemetry                                                                                                                                                            
-        --skip-validation                                                            Skip validation of OpenAPI Specification file                                                                                                                                                    
-        --authorization-header <HEADER>                                              Authorization header to use for all requests                                                                                                                                                     
-        --load-authorization-header-from-environment                                 Load the authorization header from an environment variable or define it in the .http file. You can use --authorization-header-variable-name to specify the environment variable name             
-        --authorization-header-variable-name <VARIABLE-NAME>    authorization        Name of the environment variable to load the authorization header from                                                                                                                           
-        --content-type <CONTENT-TYPE>                           application/json     Default Content-Type header to use for all requests                                                                                                                                              
-        --base-url <BASE-URL>                                                        Default Base URL to use for all requests. Use this if the OpenAPI spec doesn't explicitly specify a server URL                                                                                   
-        --output-type <OUTPUT-TYPE>                             OneRequestPerFile    OneRequestPerFile generates one .http file per request. OneFile generates a single .http file for all requests. OneFilePerTag generates one .http file per first tag associated with each request
-        --azure-scope <SCOPE>                                                        Azure Entra ID Scope to use for retrieving Access Token for Authorization header                                                                                                                 
-        --azure-tenant-id <TENANT-ID>                                                Azure Entra ID Tenant ID to use for retrieving Access Token for Authorization header                                                                                                             
-        --timeout <SECONDS>                                     120                  Timeout (in seconds) for writing files to disk                                                                                                                                                   
-        --generate-intellij-tests                                                    Generate IntelliJ tests that assert whether the response status code is 200                                                                                                                      
+                                                                DEFAULT
+    -h, --help                                                                       Prints help information
+    -v, --version                                                                    Prints version information
+    -o, --output <OUTPUT>                                       ./                   Output directory
+        --no-logging                                                                 Don't log errors or collect telemetry
+        --skip-validation                                                            Skip validation of OpenAPI Specification file
+        --authorization-header <HEADER>                                              Authorization header to use for all requests
+        --load-authorization-header-from-environment                                 Load the authorization header from an environment variable or define it in the
+                                                                                     .http file. You can use --authorization-header-variable-name to specify the
+                                                                                     environment variable name
+        --authorization-header-variable-name <VARIABLE-NAME>    authorization        Name of the environment variable to load the authorization header from
+        --content-type <CONTENT-TYPE>                           application/json     Default Content-Type header to use for all requests
+        --base-url <BASE-URL>                                                        Default Base URL to use for all requests. Use this if the OpenAPI spec doesn't
+                                                                                     explicitly specify a server URL
+        --output-type <OUTPUT-TYPE>                             OneRequestPerFile    OneRequestPerFile generates one .http file per request. OneFile generates a
+                                                                                     single .http file for all requests. OneFilePerTag generates one .http file per
+                                                                                     first tag associated with each request
+        --azure-scope <SCOPE>                                                        Azure Entra ID Scope to use for retrieving Access Token for Authorization header
+        --azure-tenant-id <TENANT-ID>                                                Azure Entra ID Tenant ID to use for retrieving Access Token for Authorization
+                                                                                     header
+        --timeout <SECONDS>                                     120                  Timeout (in seconds) for writing files to disk
+        --generate-intellij-tests                                                    Generate IntelliJ tests that assert whether the response status code is 200
+        --custom-header                                                              Add custom HTTP headers to the generated request
 ```
 
 Running the following:

--- a/src/HttpGenerator/Settings.cs
+++ b/src/HttpGenerator/Settings.cs
@@ -27,7 +27,7 @@ public class Settings : CommandSettings
     [CommandOption("--skip-validation")]
     [DefaultValue(false)]
     public bool SkipValidation { get; set; }
-    
+
     [Description("Authorization header to use for all requests")]
     [CommandOption("--authorization-header <HEADER>")]
     public string? AuthorizationHeader { get; set; }
@@ -41,7 +41,7 @@ public class Settings : CommandSettings
     [CommandOption("--authorization-header-variable-name <VARIABLE-NAME>")]
     [DefaultValue("authorization")]
     public string AuthorizationHeaderVariableName { get; set; } = "authorization";
-    
+
     [Description("Default Content-Type header to use for all requests")]
     [CommandOption("--content-type <CONTENT-TYPE>")]
     [DefaultValue("application/json")]
@@ -50,7 +50,7 @@ public class Settings : CommandSettings
     [Description("Default Base URL to use for all requests. Use this if the OpenAPI spec doesn't explicitly specify a server URL.")]
     [CommandOption("--base-url <BASE-URL>")]
     public string? BaseUrl { get; set; }
-    
+
     [Description(
         $"{nameof(OutputType.OneRequestPerFile)} generates one .http file per request. " +
         $"{nameof(OutputType.OneFile)} generates a single .http file for all requests. " +
@@ -67,7 +67,7 @@ public class Settings : CommandSettings
     [Description("Azure Entra ID Tenant ID to use for retrieving Access Token for Authorization header")]
     [CommandOption("--azure-tenant-id <TENANT-ID>")]
     public string? AzureTenantId { get; set; }
-    
+
     [Description("Timeout (in seconds) for writing files to disk")]
     [CommandOption("--timeout <SECONDS>")]
     [DefaultValue(120)]

--- a/src/HttpGenerator/Settings.cs
+++ b/src/HttpGenerator/Settings.cs
@@ -76,5 +76,9 @@ public class Settings : CommandSettings
     [Description("Generate IntelliJ tests that assert whether the response status code is 200")]
     [CommandOption("--generate-intellij-tests")]
     public bool GenerateIntelliJTests { get; set; }
-}
 
+    [Description("Add custom HTTP headers to the generated request")]
+    [CommandOption("--custom-header")]
+    [DefaultValue(new string[0])]
+    public string[]? CustomHeaders { get; set; }
+}

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -126,9 +126,9 @@ function RunTests {
                     Write-Host "Testing $filename"
                     Copy-Item $filename ./openapi.$format
                     if ($version -eq "v3.1") {
-                        Generate -format $format -output $_/$version/$format -args "--skip-validation --generate-intellij-tests" -production $Production
+                        Generate -format $format -output $_/$version/$format -args "--skip-validation --generate-intellij-tests --custom-header ""X-Custom-Header: 1234""" -production $Production
                     } else {
-                        Generate -format $format -output $_/$version/$format -args "--generate-intellij-tests" -production $Production
+                        Generate -format $format -output $_/$version/$format -args "--generate-intellij-tests --custom-header ""X-Custom-Header: 1234""" -production $Production
                     }
                 }
             }


### PR DESCRIPTION
This implements #148 

This pull request introduces the ability to add custom HTTP headers to generated requests and updates to documentation and tests to support this new feature. The most important changes include modifications to the `GeneratorSettings` class, command-line options updates, and testing framework enhancements.

### Usage example:

The following command:
```sh
httpgenerator ./openapi.json --custom-header X-Custom-Header: Value --custom-header X-Another-Header: AnotherValue
```

outputs the following .http request
```text
### Path Parameter: ID of pet to return
@petId = 0

GET /api/v3/pet/{{petId}}
Content-Type: {{contentType}}
X-Custom-Header: Value
X-Another-Header: AnotherValue
```

### New Feature: Custom HTTP Headers

* [`src/HttpGenerator.Core/GeneratorSettings.cs`](diffhunk://#diff-d9d9bd1a666c3fa45b950889ef21c127cf82322b4702f840ed221b028c44d230R56-R60): Added a new property `CustomHeaders` to the `GeneratorSettings` class to store custom HTTP headers.
* [`src/HttpGenerator.Core/HttpFileGenerator.cs`](diffhunk://#diff-6f6546de68ac0c0b21869ca2be5fe01ad04dbd88b52267f3eeb40c2df29dd4d9R212-R219): Updated the `GenerateRequest` method to include custom headers in the generated request if they are provided.

### Documentation Updates

* `README.md` and `src/HttpGenerator/README.md`: Updated the examples and options sections to include the new `--custom-header` option. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R38) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R66) [[3]](diffhunk://#diff-858a27eeb0555876115c0c62b6afb0a689329ae7d880c4f1717b4507a8bd0239L19-R22) [[4]](diffhunk://#diff-858a27eeb0555876115c0c62b6afb0a689329ae7d880c4f1717b4507a8bd0239L33-R50)

### Testing Enhancements

* [`src/HttpGenerator.Tests/SwaggerPetstoreTests.cs`](diffhunk://#diff-dbab595b89a5f69f3bd522731d74fc0ee48c7e61db989a9d0ac85d2ee897e4e3R179-R209): Added new test cases to verify that custom headers are correctly included in the generated requests. [[1]](diffhunk://#diff-dbab595b89a5f69f3bd522731d74fc0ee48c7e61db989a9d0ac85d2ee897e4e3R179-R209) [[2]](diffhunk://#diff-dbab595b89a5f69f3bd522731d74fc0ee48c7e61db989a9d0ac85d2ee897e4e3R220-R222)
* [`test/smoke-tests.ps1`](diffhunk://#diff-92210590ab59ca54396b2d8d30ab1ae7f32e5b112dfc04e4e2e91a38506e2e3bL129-R131): Updated smoke tests to include the `--custom-header` option.

### Command-line Interface Updates

* [`src/HttpGenerator/Settings.cs`](diffhunk://#diff-32c9b1ee9c9f900b2a1637ba8c48d6b2b7b566ba548ebf8b642e0409ca1feeabL79-R84): Added a new command-line option `--custom-header` to the `Settings` class.
* [`src/HttpGenerator/GenerateCommand.cs`](diffhunk://#diff-41d843431890f88eef23d702ed5c0d398125ab7c3df36722745fdcbc803c29c1R45): Updated the `ExecuteAsync` method to pass custom headers from the settings to the generator.
* [`src/HttpGenerator/Program.cs`](diffhunk://#diff-bbfbe837951ccceea5818a7aac89f10abf1f446666e9f5b9431721f4e58586b6R73-R80): Added an example usage of the `--custom-header` option.