### PR TITLE
Use --base-url even if server URL is defined

### DIFF
--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -126,9 +126,9 @@ function RunTests {
                     Write-Host "Testing $filename"
                     Copy-Item $filename ./openapi.$format
                     if ($version -eq "v3.1") {
-                        Generate -format $format -output $_/$version/$format -args "--skip-validation --generate-intellij-tests --custom-header ""X-Custom-Header: 1234""" -production $Production
+                        Generate -format $format -output $_/$version/$format -args "--skip-validation --generate-intellij-tests --custom-header ""X-Custom-Header: 1234"" --base-url https://api.example.io/" -production $Production
                     } else {
-                        Generate -format $format -output $_/$version/$format -args "--generate-intellij-tests --custom-header ""X-Custom-Header: 1234""" -production $Production
+                        Generate -format $format -output $_/$version/$format -args "--generate-intellij-tests --custom-header ""X-Custom-Header: 1234"" --base-url https://api.example.io/" -production $Production
                     }
                 }
             }


### PR DESCRIPTION
This pull request introduces several improvements and new features to the `HttpFileGenerator` class, focusing on enhancing URL handling and adding new test cases. The most important changes include updating the URL generation logic, reformatting switch cases for readability, and adding new test methods to verify the behavior when a base URL is specified or not.

### URL Handling Improvements:
* Updated the URL generation logic to handle cases where the `BaseUrl` or server URL is not well-formed or empty. (`src/HttpGenerator.Core/HttpFileGenerator.cs`)

### Code Readability:
* Reformatted the switch cases in the `Generate` method to improve readability by breaking down the parameters into multiple lines. (`src/HttpGenerator.Core/HttpFileGenerator.cs`) [[1]](diffhunk://#diff-6f6546de68ac0c0b21869ca2be5fe01ad04dbd88b52267f3eeb40c2df29dd4d9L26-R54) [[2]](diffhunk://#diff-6f6546de68ac0c0b21869ca2be5fe01ad04dbd88b52267f3eeb40c2df29dd4d9L43-R85)
* Reformatted method calls to improve readability in `GenerateFilePerTag` and `GenerateIntelliJTest`. (`src/HttpGenerator.Core/HttpFileGenerator.cs`) [[1]](diffhunk://#diff-6f6546de68ac0c0b21869ca2be5fe01ad04dbd88b52267f3eeb40c2df29dd4d9L144-L146) [[2]](diffhunk://#diff-6f6546de68ac0c0b21869ca2be5fe01ad04dbd88b52267f3eeb40c2df29dd4d9L249-R289)
* Improved the formatting of the `AppendSummary` method to make the code more readable. (`src/HttpGenerator.Core/HttpFileGenerator.cs`)

### Testing Enhancements:
* Added new test cases in `SwaggerPetstoreTests.cs` to verify that the host is ignored when a base URL is specified and used when it is not. (`src/HttpGenerator.Tests/SwaggerPetstoreTests.cs`)

### Script Updates:
* Updated the `RunTests` script to include the `--base-url` argument when generating tests, ensuring consistent URL handling during test execution. (`test/smoke-tests.ps1`)

This resolves #158