### PR TITLE
Fix Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     - name: 🧪 Test
       run: dotnet test HttpGenerator.sln -c Release    
     - name: 🗳️ Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Packages
         path: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -41,7 +41,7 @@ jobs:
       run: dotnet test src/HttpGenerator.Tests/HttpGenerator.Tests.csproj -c Release --collect "Code coverage" -p:UseSourceLink=true -p:PackageVersion="${{ env.VERSION }}"
     
     - name: 🗳️ Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Packages
         path: |

--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -31,7 +31,7 @@ jobs:
         shell: pwsh
         run: Get-ChildItem -Filter *.nupkg -Recurse | ForEach-Object { Move-Item -Path $_ -Destination . }
       - name: Publish artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Packages
           path: |


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to use the latest version of the `actions/upload-artifact` action. The most important changes are:

Updates to GitHub Actions workflows:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L40-R40): Updated the `actions/upload-artifact` action from version `v3` to `v4`.
* [`.github/workflows/codecov.yml`](diffhunk://#diff-512f30627f95d7fcdc76dc362d896351e9a4539994b7ab00b41979e653a6d0a9L44-R44): Updated the `actions/upload-artifact` action from version `v3` to `v4`.
* [`.github/workflows/release-template.yml`](diffhunk://#diff-5634e481e2c4e165ffcd1de5aab959de4f65f0ff6eff699d52e53c19bc2811faL34-R34): Updated the `actions/upload-artifact` action from version `v3` to `v4`.