### PR TITLE
Revert NSwag back to v14.4.0

### DIFF
--- a/src/HttpGenerator.Core/HttpGenerator.Core.csproj
+++ b/src/HttpGenerator.Core/HttpGenerator.Core.csproj
@@ -14,8 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="NSwag.CodeGeneration.CSharp" Version="14.5.0" />
-    <PackageReference Include="NSwag.Core.Yaml" Version="14.5.0" />
+    <PackageReference Include="NSwag.CodeGeneration.CSharp" Version="14.4.0" />
+    <PackageReference Include="NSwag.Core.Yaml" Version="14.4.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.8" />
   </ItemGroup>


### PR DESCRIPTION
Reverts christianhelle/httpgenerator#230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Downgraded underlying NSwag dependencies used for code generation and YAML handling to version 14.4.0.
  * No user-facing functionality, UI, or workflow changes are introduced by this update.
  * Builds and runtime behavior are expected to remain consistent; no action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->