### PR TITLE
Add skip header option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -403,3 +403,7 @@ test/openapi.yaml
 *.http
 src/VSCode/out
 src/VSCode/*.vsix
+
+# nvim 
+.ignore
+

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 <!--toc:start-->
+
 - [HTTP File Generator](#http-file-generator)
   - [Installation](#installation)
-  - [Usage](#usage)
-    - [Error Logging, Telemetry, and Privacy](#error-logging-telemetry-and-privacy)
-    - [Visual Studio 2022 Extension](#visual-studio-2022-extension)
-<!--toc:end-->
+  - [Usage](#usage) - [Error Logging, Telemetry, and Privacy](#error-logging-telemetry-and-privacy) - [Visual Studio 2022 Extension](#visual-studio-2022-extension)
+  <!--toc:end-->
+
 #
+
 [![Build](https://github.com/christianhelle/httpgenerator/actions/workflows/build.yml/badge.svg)](https://github.com/christianhelle/httpgenerator/actions/workflows/build.yml)
 [![Smoke Tests](https://github.com/christianhelle/httpgenerator/actions/workflows/smoke-tests.yml/badge.svg)](https://github.com/christianhelle/httpgenerator/actions/workflows/smoke-tests.yml)
 [![NuGet](https://img.shields.io/nuget/v/httpgenerator?color=blue)](https://www.nuget.org/packages/httpgenerator)
@@ -72,6 +73,7 @@ OPTIONS:
         --timeout <SECONDS>                                     120                  Timeout (in seconds) for writing files to disk
         --generate-intellij-tests                                                    Generate IntelliJ tests that assert whether the response status code is 200
         --custom-header                                                              Add custom HTTP headers to the generated request
+        --skip-headers                                                               Don't generate header parameters in the files
 ```
 
 Running the following:
@@ -87,14 +89,14 @@ Outputs the following:
 Which will produce the following files:
 
 ```sh
--rw-r--r-- 1 christian 197121  593 Dec 10 10:44 DeleteOrder.http        
+-rw-r--r-- 1 christian 197121  593 Dec 10 10:44 DeleteOrder.http
 -rw-r--r-- 1 christian 197121  231 Dec 10 10:44 DeletePet.http
 -rw-r--r-- 1 christian 197121  358 Dec 10 10:44 DeleteUser.http
 -rw-r--r-- 1 christian 197121  432 Dec 10 10:44 GetFindPetsByStatus.http
--rw-r--r-- 1 christian 197121  504 Dec 10 10:44 GetFindPetsByTags.http  
--rw-r--r-- 1 christian 197121  371 Dec 10 10:44 GetInventory.http       
--rw-r--r-- 1 christian 197121  247 Dec 10 10:44 GetLoginUser.http       
--rw-r--r-- 1 christian 197121  291 Dec 10 10:44 GetLogoutUser.http      
+-rw-r--r-- 1 christian 197121  504 Dec 10 10:44 GetFindPetsByTags.http
+-rw-r--r-- 1 christian 197121  371 Dec 10 10:44 GetInventory.http
+-rw-r--r-- 1 christian 197121  247 Dec 10 10:44 GetLoginUser.http
+-rw-r--r-- 1 christian 197121  291 Dec 10 10:44 GetLogoutUser.http
 -rw-r--r-- 1 christian 197121  540 Dec 10 10:44 GetOrderById.http
 -rw-r--r-- 1 christian 197121  275 Dec 10 10:44 GetPetById.http
 -rw-r--r-- 1 christian 197121  245 Dec 10 10:44 GetUserByName.http
@@ -180,7 +182,7 @@ Content-Type: {{contentType}}
 > {%
     client.test("Request executed successfully", function() {
         client.assert(
-            response.status === 200, 
+            response.status === 200,
             "Response status is not 200");
     });
 %}
@@ -196,7 +198,7 @@ az account get-access-token --scope [Some Application ID URI]/.default `
         https://api.example.com/swagger/v1/swagger.json `
         --authorization-header ("Bearer " + $_.accessToken) `
         --base-url https://api.example.com `
-        --output ./HttpFiles 
+        --output ./HttpFiles
 }
 ```
 
@@ -207,14 +209,14 @@ httpgenerator `
   https://api.example.com/swagger/v1/swagger.json `
   --azure-scope [Some Application ID URI]/.default `
   --base-url https://api.example.com `
-  --output ./HttpFiles 
+  --output ./HttpFiles
 ```
 
 ### Error Logging, Telemetry, and Privacy
 
 This tool collects errors and tracks features usages to service called [Exceptionless](https://exceptionless.com/)
 
-By default, error logging and telemetry collection is enabled but it is possible to **opt-out** by using the `--no-logging` CLI argument. 
+By default, error logging and telemetry collection is enabled but it is possible to **opt-out** by using the `--no-logging` CLI argument.
 
 User tracking is done anonymously using the **Support key** shown when running the tool and a generated anonymous identity based on a secure hash algorithm of username@host.
 

--- a/src/HttpGenerator.Core/GeneratorSettings.cs
+++ b/src/HttpGenerator.Core/GeneratorSettings.cs
@@ -58,6 +58,11 @@ public class GeneratorSettings
     /// Gets or sets custom HTTP headers to add to the generated request
     /// </summary>
     public string[]? CustomHeaders { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether to skip generating header parameters
+    /// </summary>
+    public bool SkipHeaders { get; set; }
 }
 
 /// <summary>

--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -116,6 +116,10 @@ public static class HttpFileGenerator
 
     private static void WriteFileHeaders(GeneratorSettings settings, StringBuilder code, string baseUrl)
     {
+        if (settings.SkipHeaders)
+        {
+            return;
+        }
         code.AppendLine($"@baseUrl = {baseUrl}");
         code.AppendLine($"@contentType = {settings.ContentType}");
 

--- a/src/HttpGenerator/GenerateCommand.cs
+++ b/src/HttpGenerator/GenerateCommand.cs
@@ -22,8 +22,7 @@ public class GenerateCommand : AsyncCommand<Settings>
             var stopwatch = Stopwatch.StartNew();
             DisplayHeader(settings);
 
-            if (!settings.SkipValidation)
-                await ValidateOpenApiSpec(settings);
+            if (!settings.SkipValidation) await ValidateOpenApiSpec(settings);
 
             await AcquireAzureEntraIdToken(settings);
 
@@ -39,8 +38,9 @@ public class GenerateCommand : AsyncCommand<Settings>
                 Timeout = settings.Timeout,
                 GenerateIntelliJTests = settings.GenerateIntelliJTests,
                 CustomHeaders = settings.CustomHeaders,
+                SkipHeaders = settings.SkipHeaders,
             };
-            var result = await HttpFileGenerator.Generate(generatorSettings);
+            GeneratorResult result = await HttpFileGenerator.Generate(generatorSettings);
             await Analytics.LogFeatureUsage(settings);
             await WriteFiles(settings, result);
 

--- a/src/HttpGenerator/Program.cs
+++ b/src/HttpGenerator/Program.cs
@@ -10,17 +10,11 @@ internal static class Program
 
     private static int Main(string[] args)
     {
-        if (args.Length == 0)
-        {
-            args = new[]
-            {
-                "--help"
-            };
-        }
+        if (args.Length == 0) args = ["--help"];
 
-        System.Console.OutputEncoding = System.Text.Encoding.UTF8;
+        Console.OutputEncoding = System.Text.Encoding.UTF8;
 
-        var app = new CommandApp<GenerateCommand>();
+        CommandApp<GenerateCommand> app = new();
         app.Configure(
             configuration =>
             {

--- a/src/HttpGenerator/README.md
+++ b/src/HttpGenerator/README.md
@@ -48,6 +48,7 @@ OPTIONS:
         --timeout <SECONDS>                                     120                  Timeout (in seconds) for writing files to disk
         --generate-intellij-tests                                                    Generate IntelliJ tests that assert whether the response status code is 200
         --custom-header                                                              Add custom HTTP headers to the generated request
+        --skip-headers                                                               Don't generate header parameters in the files
 ```
 
 Running the following:
@@ -63,14 +64,14 @@ Outputs the following:
 Which will produce the following files:
 
 ```sh
--rw-r--r-- 1 christian 197121  593 Dec 10 10:44 DeleteOrder.http        
+-rw-r--r-- 1 christian 197121  593 Dec 10 10:44 DeleteOrder.http
 -rw-r--r-- 1 christian 197121  231 Dec 10 10:44 DeletePet.http
 -rw-r--r-- 1 christian 197121  358 Dec 10 10:44 DeleteUser.http
 -rw-r--r-- 1 christian 197121  432 Dec 10 10:44 GetFindPetsByStatus.http
--rw-r--r-- 1 christian 197121  504 Dec 10 10:44 GetFindPetsByTags.http  
--rw-r--r-- 1 christian 197121  371 Dec 10 10:44 GetInventory.http       
--rw-r--r-- 1 christian 197121  247 Dec 10 10:44 GetLoginUser.http       
--rw-r--r-- 1 christian 197121  291 Dec 10 10:44 GetLogoutUser.http      
+-rw-r--r-- 1 christian 197121  504 Dec 10 10:44 GetFindPetsByTags.http
+-rw-r--r-- 1 christian 197121  371 Dec 10 10:44 GetInventory.http
+-rw-r--r-- 1 christian 197121  247 Dec 10 10:44 GetLoginUser.http
+-rw-r--r-- 1 christian 197121  291 Dec 10 10:44 GetLogoutUser.http
 -rw-r--r-- 1 christian 197121  540 Dec 10 10:44 GetOrderById.http
 -rw-r--r-- 1 christian 197121  275 Dec 10 10:44 GetPetById.http
 -rw-r--r-- 1 christian 197121  245 Dec 10 10:44 GetUserByName.http
@@ -156,7 +157,7 @@ Content-Type: {{contentType}}
 > {%
     client.test("Request executed successfully", function() {
         client.assert(
-            response.status === 200, 
+            response.status === 200,
             "Response status is not 200");
     });
 %}
@@ -172,7 +173,7 @@ az account get-access-token --scope [Some Application ID URI]/.default `
         https://api.example.com/swagger/v1/swagger.json `
         --authorization-header ("Bearer " + $_.accessToken) `
         --base-url https://api.example.com `
-        --output ./HttpFiles 
+        --output ./HttpFiles
 }
 ```
 
@@ -183,7 +184,7 @@ httpgenerator `
   https://api.example.com/swagger/v1/swagger.json `
   --azure-scope [Some Application ID URI]/.default `
   --base-url https://api.example.com `
-  --output ./HttpFiles 
+  --output ./HttpFiles
 ```
 
 #

--- a/src/HttpGenerator/Settings.cs
+++ b/src/HttpGenerator/Settings.cs
@@ -46,7 +46,7 @@ public class Settings : CommandSettings
     [CommandOption("--content-type <CONTENT-TYPE>")]
     [DefaultValue("application/json")]
     public string ContentType { get; set; } = "application/json";
-    
+
     [Description("Default Base URL to use for all requests. Use this if the OpenAPI spec doesn't explicitly specify a server URL.")]
     [CommandOption("--base-url <BASE-URL>")]
     public string? BaseUrl { get; set; }
@@ -59,11 +59,11 @@ public class Settings : CommandSettings
     [DefaultValue(OutputType.OneRequestPerFile)]
     [AllowedValues(nameof(OutputType.OneRequestPerFile), nameof(OutputType.OneFile))]
     public OutputType OutputType { get; set; } = OutputType.OneRequestPerFile;
-    
+
     [Description("Azure Entra ID Scope to use for retrieving Access Token for Authorization header")]
     [CommandOption("--azure-scope <SCOPE>")]
     public string? AzureScope { get; set; }
-    
+
     [Description("Azure Entra ID Tenant ID to use for retrieving Access Token for Authorization header")]
     [CommandOption("--azure-tenant-id <TENANT-ID>")]
     public string? AzureTenantId { get; set; }
@@ -81,4 +81,8 @@ public class Settings : CommandSettings
     [CommandOption("--custom-header")]
     [DefaultValue(new string[0])]
     public string[]? CustomHeaders { get; set; }
+
+    [Description("Don't generate header parameters in the files")]
+    [CommandOption("--skip-headers")]
+    public bool SkipHeaders { get; set; }
 }


### PR DESCRIPTION
---
name: Pull request
title: ""
labels: enhancement
assignees: PolarTango
---

## Description:

Option, that remove headers like @hostUrl or @contantType from start of the file.
Provides better experience when using .env file to not manually remove it from every file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a --skip-headers option to the generator to omit HTTP header lines (e.g., base URL, content type) in output files. Default behavior is unchanged unless this flag is used.

* **Refactor**
  * Minor CLI and initialization cleanups with no impact on behavior.

* **Chores**
  * Updated ignore rules to exclude files/directories named .ignore.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->