### PR TITLE
Fix Code Coverage workflow

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -52,7 +52,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         directory: src
-        file: coverage.xml
+        files: '**/coverage.cobertura.xml'
         flags: unittests
         fail_ci_if_error: true
         verbose: true


### PR DESCRIPTION
Switch to using "XPlat Code coverage" for testing, remove the unnecessary conversion step from the Codecov workflow, and update the upload process to utilize coverage.cobertura.xml for report submissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage collection to a cross-platform option in the test workflow.
  * Simplified the workflow by removing the coverage conversion step.
  * Adjusted coverage upload to use a broader file pattern for detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->