### PR TITLE
Null-guard operation.Parameters and parameter entries

### DIFF
--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -421,9 +421,8 @@ public static class HttpFileGenerator
         IOperationNameGenerator operationNameGenerator,
         StringBuilder code)
     {
-        var parameters = operation
-            .Parameters
-            .Where(c => c.In == ParameterLocation.Path || c.In == ParameterLocation.Query)
+        var parameters = (operation.Parameters ?? Enumerable.Empty<OpenApiParameter>())
+            .Where(c => c is not null && (c.In == ParameterLocation.Path || c.In == ParameterLocation.Query))
             .ToArray();
 
         var parameterNameMap = new Dictionary<string, string>();


### PR DESCRIPTION
## Summary

Fixes #310 and #311 — NullReferenceException when processing large OpenAPI specs like the GitHub Enterprise API (1083 operations, 35493 schemas).

## Root Cause

In \AppendParameters()\, the code called \.Where()\ directly on \operation.Parameters\ without guarding against:
1. \operation.Parameters\ being null (Issue #310)
2. Individual parameter entries within the list being null (Issue #311)

Both scenarios occur in the GitHub API spec where unresolved \\\ references can leave null values in the parameters collection.

## Changes

- \src/HttpGenerator.Core/HttpFileGenerator.cs\: Added null-conditional access to \operation.Parameters\ and filtered null entries before LINQ query.

## Testing

- Existing unit tests pass (162/162)
- Manual validation with petstore.json produces correct output
- Regression tests being added by Bishop in a separate PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of HTTP file generation to handle missing or null parameter data, preventing potential errors during code generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->