### PR TITLE
Regression tests for null operation.Parameters

### DIFF
--- a/src/HttpGenerator.Tests/HttpGenerator.Tests.csproj
+++ b/src/HttpGenerator.Tests/HttpGenerator.Tests.csproj
@@ -37,6 +37,7 @@
     <EmbeddedResource Include="Resources\V3\SwaggerPetstoreWithDifferentHeaders.yaml" />
     <EmbeddedResource Include="Resources\V3\SwaggerPetstoreWithMultlineDescriptions.json" />
     <EmbeddedResource Include="Resources\V3\SwaggerPetstoreWithMultlineDescriptions.yaml" />
+    <EmbeddedResource Include="Resources\V3\NullParameters.json" />
     <EmbeddedResource Include="Resources\V31\non-oauth-scopes.json" />
     <EmbeddedResource Include="Resources\V31\non-oauth-scopes.yaml" />
     <EmbeddedResource Include="Resources\V31\webhook-example.json" />

--- a/src/HttpGenerator.Tests/NullParametersTests.cs
+++ b/src/HttpGenerator.Tests/NullParametersTests.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+using FluentAssertions.Execution;
+using HttpGenerator.Core;
+using HttpGenerator.Tests.Resources;
+
+namespace HttpGenerator.Tests;
+
+public class NullParametersTests
+{
+    [Theory]
+    [InlineData(OutputType.OneRequestPerFile)]
+    [InlineData(OutputType.OneFile)]
+    [InlineData(OutputType.OneFilePerTag)]
+    public async Task Generate_Should_Not_Throw_When_Operation_Has_Null_Parameters(OutputType outputType)
+    {
+        var act = async () => await GenerateCode(outputType);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Theory]
+    [InlineData(OutputType.OneRequestPerFile)]
+    [InlineData(OutputType.OneFile)]
+    [InlineData(OutputType.OneFilePerTag)]
+    public async Task Generate_Should_Return_Valid_Files_When_Operation_Has_Null_Parameters(OutputType outputType)
+    {
+        var result = await GenerateCode(outputType);
+
+        using var scope = new AssertionScope();
+        result.Should().NotBeNull();
+        result.Files.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Generate_Should_Include_Operation_Without_Parameters_In_Output()
+    {
+        var result = await GenerateCode(OutputType.OneFile);
+
+        using var scope = new AssertionScope();
+        result.Should().NotBeNull();
+        result.Files.Should().ContainSingle();
+        
+        var content = result.Files.First().Content;
+        content.Should().Contain("GET");
+        content.Should().Contain("/no-parameters");
+    }
+
+    [Fact]
+    public async Task Generate_Should_Include_Operation_With_Valid_Parameters_In_Output()
+    {
+        var result = await GenerateCode(OutputType.OneFile);
+
+        using var scope = new AssertionScope();
+        result.Should().NotBeNull();
+        result.Files.Should().ContainSingle();
+        
+        var content = result.Files.First().Content;
+        content.Should().Contain("GET");
+        content.Should().Contain("/with-parameters");
+        content.Should().Contain("@");
+        content.Should().Contain("id");
+        content.Should().Contain("status");
+    }
+
+    [Fact]
+    public async Task Generate_Should_Create_Separate_Files_For_Each_Operation_In_OneRequestPerFile_Mode()
+    {
+        var result = await GenerateCode(OutputType.OneRequestPerFile);
+
+        using var scope = new AssertionScope();
+        result.Should().NotBeNull();
+        result.Files.Should().HaveCount(2);
+        
+        var noParamsFile = result.Files.FirstOrDefault(f => f.Content.Contains("/no-parameters"));
+        noParamsFile.Should().NotBeNull();
+        
+        var withParamsFile = result.Files.FirstOrDefault(f => f.Content.Contains("/with-parameters"));
+        withParamsFile.Should().NotBeNull();
+    }
+
+    private static async Task<GeneratorResult> GenerateCode(OutputType outputType)
+    {
+        var json = EmbeddedResources.GetSwaggerPetstore(Samples.NullParametersJsonV3);
+        var swaggerFile = await TestFile.CreateSwaggerFile(json, "NullParameters.json");
+        return await HttpFileGenerator.Generate(
+            new GeneratorSettings
+            {
+                OpenApiPath = swaggerFile,
+                OutputType = outputType,
+                GenerateIntelliJTests = true,
+            });
+    }
+}

--- a/src/HttpGenerator.Tests/Resources/EmbeddedResources.cs
+++ b/src/HttpGenerator.Tests/Resources/EmbeddedResources.cs
@@ -95,6 +95,16 @@ public static class EmbeddedResources
         return reader.ReadToEnd();
     }
 
+    public static string NullParametersJsonV3
+    {
+        get
+        {
+            using var stream = GetStream("V3.NullParameters.json");
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+    }
+
     public static string GetSwaggerPetstore(Samples version)
     {
         return version switch
@@ -108,6 +118,7 @@ public static class EmbeddedResources
             Samples.PetstoreYamlV3WithDifferentHeaders => SwaggerPetstoreYamlV3WithDifferentHeaders,
             Samples.PetstoreJsonV3WithMultlineDescriptions => GetStringFromEmbeddedResource("V3.SwaggerPetstoreWithMultlineDescriptions.json"),
             Samples.PetstoreYamlV3WithMultlineDescriptions => GetStringFromEmbeddedResource("V3.SwaggerPetstoreWithMultlineDescriptions.yaml"),
+            Samples.NullParametersJsonV3 => NullParametersJsonV3,
             _ => SwaggerPetstoreJsonV3
         };
     }

--- a/src/HttpGenerator.Tests/Resources/Samples.cs
+++ b/src/HttpGenerator.Tests/Resources/Samples.cs
@@ -11,5 +11,6 @@ public enum Samples
     PetstoreYamlV2WithDifferentHeaders,
     PetstoreYamlV3WithDifferentHeaders, 
     PetstoreYamlV3WithMultlineDescriptions, 
-    PetstoreJsonV3WithMultlineDescriptions,    
+    PetstoreJsonV3WithMultlineDescriptions,
+    NullParametersJsonV3,
 }

--- a/src/HttpGenerator.Tests/Resources/V3/NullParameters.json
+++ b/src/HttpGenerator.Tests/Resources/V3/NullParameters.json
@@ -1,0 +1,86 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Null Parameters Test API",
+    "description": "API for testing null parameter handling",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {
+    "/no-parameters": {
+      "get": {
+        "summary": "Operation with no parameters field",
+        "description": "This operation has no parameters field to test null Parameters collection",
+        "operationId": "getNoParameters",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/with-parameters": {
+      "get": {
+        "summary": "Operation with valid parameters",
+        "description": "This operation has valid parameters to verify normal case still works",
+        "operationId": "getWithParameters",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "The ID parameter"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Status filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "status": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/OpenAPI/v3.0/null-parameters.json
+++ b/test/OpenAPI/v3.0/null-parameters.json
@@ -1,0 +1,86 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Null Parameters Test API",
+    "description": "API for testing null parameter handling",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {
+    "/no-parameters": {
+      "get": {
+        "summary": "Operation with no parameters field",
+        "description": "This operation has no parameters field to test null Parameters collection",
+        "operationId": "getNoParameters",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/with-parameters": {
+      "get": {
+        "summary": "Operation with valid parameters",
+        "description": "This operation has valid parameters to verify normal case still works",
+        "operationId": "getWithParameters",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "The ID parameter"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Status filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "status": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds regression tests for #310 and #311 to prevent future regressions of the null Parameters NullReferenceException.

## Tests Added

- \NullParametersTests.cs\: Tests that generation succeeds when an operation has null Parameters
- \	est/OpenAPI/v3.0/null-parameters.json\: Minimal fixture with an operation that has no parameters field
- \src/HttpGenerator.Tests/Resources/V3/NullParameters.json\: Embedded resource version of the fixture

## Test Coverage

9 new tests verify:
- No exception is thrown when operation.Parameters is null (all output types)
- Valid files are generated with null Parameters (all output types)
- Operations without parameters are included in output
- Operations with valid parameters still work correctly
- OneRequestPerFile mode creates separate files for each operation

All 171 tests pass including the 9 new regression tests.

## Related

Implementation fix: PR for #310/#311