### PR TITLE
Merge path-level parameters into operation parameters

### DIFF
--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -421,8 +421,20 @@ public static class HttpFileGenerator
         IOperationNameGenerator operationNameGenerator,
         StringBuilder code)
     {
-        var parameters = (operation.Parameters ?? Enumerable.Empty<OpenApiParameter>())
-            .Where(c => c is not null && (c.In == ParameterLocation.Path || c.In == ParameterLocation.Query))
+        // Merge path-level parameters with operation-level parameters.
+        // Operation-level parameters override path-level ones with the same name+in.
+        var pathLevelParams = operationPath.Value.Parameters
+            ?? Enumerable.Empty<OpenApiParameter>();
+
+        var operationParams = operation.Parameters
+            ?? Enumerable.Empty<OpenApiParameter>();
+
+        var parameters = pathLevelParams
+            .Where(p => p is not null)
+            .Concat(operationParams.Where(p => p is not null))
+            .GroupBy(p => (p.Name, p.In))
+            .Select(g => g.Last()) // operation-level wins (it's appended last)
+            .Where(p => p.In == ParameterLocation.Path || p.In == ParameterLocation.Query)
             .ToArray();
 
         var parameterNameMap = new Dictionary<string, string>();


### PR DESCRIPTION
## Summary

Fixes #312 — path-level parameters defined on \OpenApiPathItem\ are now merged into the effective parameter list for each operation.

## Root Cause

\AppendParameters()\ only consulted \operation.Parameters\, completely ignoring \pathItem.Parameters\. APIs like GitHub's define shared path parameters (e.g. \owner\, \epo\) at the path item level, meaning they were silently omitted from generated \.http\ files.

## Behavior Change

Per the OpenAPI 3.0 spec, the effective parameter list is: path-level params + operation-level params, with operation-level taking precedence on name+in collision.

## Testing

- All existing unit tests pass (171 tests)
- Manual validation with petstore.json produces correct output
- Regression tests to be added by Bishop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP file generation to properly include and merge path-level and operation-level parameters. Operation-level parameter definitions now correctly take precedence over path-level definitions when both specify the same parameter. Null parameters are properly filtered out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->