### PR TITLE
Generate meaningful JSON samples for allOf/oneOf/anyOf schemas

### DIFF
--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -510,7 +510,26 @@ public static class HttpFileGenerator
     {
         if (schema == null) return null;
 
-        // Very basic JSON sample generation
+        // Handle composition keywords (allOf, oneOf, anyOf)
+        if (schema.AllOf?.Count > 0)
+            return GenerateSampleJson(schema.AllOf.FirstOrDefault(s => s != null));
+
+        if (schema.OneOf?.Count > 0)
+            return GenerateSampleJson(schema.OneOf.FirstOrDefault(s => s != null));
+
+        if (schema.AnyOf?.Count > 0)
+            return GenerateSampleJson(schema.AnyOf.FirstOrDefault(s => s != null));
+
+        // Handle object with properties - generate property-aware samples
+        if (schema.Properties?.Count > 0)
+        {
+            var props = schema.Properties
+                .Take(3) // limit for readability
+                .Select(p => $"  \"{p.Key}\": {GetPropertySampleValue(p.Value)}");
+            return "{\n" + string.Join(",\n", props) + "\n}";
+        }
+
+        // Basic type-based JSON sample generation
         return schema.Type?.ToLowerInvariant() switch
         {
             "object" => "{\n  \"property\": \"value\"\n}",
@@ -520,6 +539,32 @@ public static class HttpFileGenerator
             "number" => "0",
             "boolean" => "true",
             _ => "{}"
+        };
+    }
+
+    private static string GetPropertySampleValue(OpenApiSchema schema)
+    {
+        if (schema == null) return "\"value\"";
+
+        // Recursively handle nested composition
+        if (schema.AllOf?.Count > 0)
+            return GetPropertySampleValue(schema.AllOf.FirstOrDefault(s => s != null) ?? schema);
+
+        if (schema.OneOf?.Count > 0)
+            return GetPropertySampleValue(schema.OneOf.FirstOrDefault(s => s != null) ?? schema);
+
+        if (schema.AnyOf?.Count > 0)
+            return GetPropertySampleValue(schema.AnyOf.FirstOrDefault(s => s != null) ?? schema);
+
+        return schema.Type?.ToLowerInvariant() switch
+        {
+            "string" => "\"example\"",
+            "integer" => "0",
+            "number" => "0.0",
+            "boolean" => "true",
+            "array" => "[\"item\"]",
+            "object" => "{\"property\": \"value\"}",
+            _ => "\"value\""
         };
     }
 }


### PR DESCRIPTION
## Summary

Fixes #313 — \GenerateSampleJson()\ returned a useless \{}\ for any schema using composition keywords (\llOf\, \oneOf\, \nyOf\), which are widespread in complex APIs like GitHub's.

## Changes

Enhanced \GenerateSampleJson()\ to:
1. Delegate to the first sub-schema for \llOf\/\oneOf\/\nyOf\
2. Generate property-aware samples for object schemas with known \properties\

## Testing

- All existing unit tests pass (180/184 successful - 4 pre-existing failures in PathLevelParametersTests unrelated to this change)
- Manual validation with petstore.json succeeds and generates property-aware JSON samples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced JSON sample generation to produce more accurate and detailed examples based on API schema definitions.
  * Improved handling of complex schema structures with better representation of object properties in generated samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->