### PR TITLE
Deduplicate filenames in OneRequestPerFile mode

### DIFF
--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -157,6 +157,7 @@ public static class HttpFileGenerator
             return new GeneratorResult(files);
         }
         
+        var seenFilenames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         files.Capacity = document.Paths.Count;
         foreach (var kv in document.Paths)
         {
@@ -176,7 +177,7 @@ public static class HttpFileGenerator
                 var operation = operations_kv.Value;
                 var verb = operations_kv.Key.CapitalizeFirstCharacter();
                 var name = operationNameGenerator.GetOperationName(document, kv.Key, verb, operation);
-                var filename = $"{name.CapitalizeFirstCharacter()}.http";
+                var filename = GetUniqueFilename($"{name.CapitalizeFirstCharacter()}.http", seenFilenames);
 
                 var code = new StringBuilder();
                 WriteFileHeaders(settings, code, baseUrl);
@@ -466,6 +467,22 @@ public static class HttpFileGenerator
 
         code.AppendLine();
         return parameterNameMap;
+    }
+
+    private static string GetUniqueFilename(string filename, HashSet<string> seen)
+    {
+        if (seen.Add(filename))
+            return filename;
+
+        var name = Path.GetFileNameWithoutExtension(filename);
+        var ext = Path.GetExtension(filename);
+        var counter = 2;
+        string candidate;
+        do
+        {
+            candidate = $"{name}_{counter++}{ext}";
+        } while (!seen.Add(candidate));
+        return candidate;
     }
 
     private static string GetParameterName(


### PR DESCRIPTION
## Summary

When multiple operations share the same generated name (e.g., missing operationId causes NSwag to generate identical names for different paths), output files would collide, causing earlier files to be overwritten silently.

## Changes

- Added \GetUniqueFilename()\ helper that tracks seen filenames with a \HashSet<string>\ and appends \_N\ suffix for duplicates
- Updated \GenerateMultipleFiles()\ to use this helper

## Test

All 184 existing tests pass. No new behavior change for non-colliding filenames.

Closes #314