### PR TITLE
chore: upgrade Spectre.Console.Cli

### DIFF
--- a/.squad/agents/hicks/history.md
+++ b/.squad/agents/hicks/history.md
@@ -29,6 +29,18 @@ HTTP File Generator generates `.http` files from OpenAPI specs. Core logic is in
 
 ## Learnings
 
+### Issue #329: Spectre.Console.Cli patch refresh
+**Date:** 2026-03-20
+
+**Problem:** `Spectre.Console.Cli` in `src\HttpGenerator\HttpGenerator.csproj` was pinned to `0.53.0` and needed the planned patch refresh to `0.53.1`.
+
+**Solution:** Updated the direct package reference in:
+- `src\HttpGenerator\HttpGenerator.csproj`
+
+**Pattern learned:** For CLI framework patch updates in this repo, keep the change scoped to the CLI project file and validate both the standard solution pipeline and the CLI surface area. The key smoke check is `dotnet run --project src\HttpGenerator\HttpGenerator.csproj -- --help`, with the local `petstore.json` generation run as a regression guard to confirm the generator still emits 19 `.http` files.
+
+**Testing:** `dotnet restore HttpGenerator.sln`, `dotnet build HttpGenerator.sln --configuration Release`, `dotnet test HttpGenerator.sln --configuration Release`, `dotnet run --project src\HttpGenerator\HttpGenerator.csproj -- --help`, and a local petstore generation run all passed. The petstore validation still produced 19 `.http` files.
+
 ### PR TBD: Microsoft.SourceLink.GitHub metadata refresh (issue #328)
 **Date:** 2026-03-20
 

--- a/.squad/skills/cli-patch-refresh/SKILL.md
+++ b/.squad/skills/cli-patch-refresh/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: "cli-patch-refresh"
+description: "Safely implement CLI framework patch-level NuGet bumps in HTTP File Generator"
+domain: "dependencies"
+confidence: "high"
+source: "issue #329 / deps-003"
+---
+
+## Context
+
+Use this pattern for direct patch-level NuGet upgrades that primarily affect the CLI entrypoint, such as `Spectre.Console.Cli`.
+
+## Patterns
+
+### Scope
+
+- Keep the code change limited to the exact `<PackageReference>` in `src\HttpGenerator\HttpGenerator.csproj` when the upgrade only affects the CLI app.
+- Avoid bundling other dependency bumps or refactors into the same PR.
+
+### Validation
+
+- Run the standard solution pipeline after the bump:
+  - `dotnet restore HttpGenerator.sln`
+  - `dotnet build HttpGenerator.sln --configuration Release`
+  - `dotnet test HttpGenerator.sln --configuration Release`
+- Run the CLI help smoke check:
+  - `dotnet run --project src\HttpGenerator\HttpGenerator.csproj -- --help`
+- Run the local generator regression check against `test\OpenAPI\v3.0\petstore.json` and confirm 19 generated `.http` files.
+
+### Workflow
+
+- Use a dedicated feature branch and worktree for the dependency issue.
+- Keep the commit small and dependency-focused so CLI behavior changes are easy to spot in review.
+
+## Anti-Patterns
+
+- Do not skip the `--help` smoke check for CLI framework updates.
+- Do not assume a patch-level bump is safe without confirming the generator still works on the local petstore fixture.

--- a/src/HttpGenerator/HttpGenerator.csproj
+++ b/src/HttpGenerator/HttpGenerator.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.23.0" />
         <PackageReference Include="Microsoft.OpenApi.OData" Version="1.7.5" />
         <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.28" />
-        <PackageReference Include="Spectre.Console.Cli" Version="0.53.0" />
+        <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- bump Spectre.Console.Cli from 0.53.0 to 0.53.1 in the CLI project
- refresh Hicks learning notes for the dependency stream
- add a reusable squad skill for CLI patch dependency refreshes

## Validation
- dotnet restore HttpGenerator.sln
- dotnet build HttpGenerator.sln --configuration Release
- dotnet test HttpGenerator.sln --configuration Release
- dotnet run --project src\HttpGenerator\HttpGenerator.csproj -- --help
- dotnet run --project src\HttpGenerator\HttpGenerator.csproj -- test\OpenAPI\v3.0\petstore.json --output .tmp-petstore --no-logging

Closes #329
