### PR TITLE
[deps-005] Migrate OpenAPI reader pipeline

### DIFF
--- a/.squad/decisions/inbox/hicks-deps-005-openapi-rescue.md
+++ b/.squad/decisions/inbox/hicks-deps-005-openapi-rescue.md
@@ -1,0 +1,5 @@
+# deps-005 rescue decisions
+
+- Preserve the existing CLI policy that OpenAPI 3.1+ requires `--skip-validation`, even though `Microsoft.OpenApi` 3.4.0 can parse 3.1 documents. The validator now loads with the new reader pipeline, then throws `OpenApiUnsupportedSpecVersionException` for 3.1+ so the user-facing behavior and docs stay stable in this milestone.
+- Remove the unused `Microsoft.OpenApi.OData` package from `src/HttpGenerator/HttpGenerator.csproj` instead of carrying it forward, because there are no source references to OData in this repo.
+- Keep follow-up behavior changes out of this branch. In particular, broader 3.1 sample-generation semantics (for example multi-type schema nuances) should be handled in a later dependency milestone instead of expanding deps-005.

--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 
 namespace HttpGenerator.Core;
 
@@ -243,7 +243,7 @@ public static class HttpFileGenerator
 
     private static string GenerateRequest(
         OpenApiDocument document,
-        KeyValuePair<string, OpenApiPathItem> operationPath,
+        KeyValuePair<string, IOpenApiPathItem> operationPath,
         IOperationNameGenerator operationNameGenerator,
         GeneratorSettings settings,
         string verb,
@@ -351,7 +351,7 @@ public static class HttpFileGenerator
 
     private static void AppendSummary(
         string verb,
-        KeyValuePair<string, OpenApiPathItem> kv,
+        KeyValuePair<string, IOpenApiPathItem> kv,
         OpenApiOperation operation,
         StringBuilder code)
     {
@@ -419,7 +419,7 @@ public static class HttpFileGenerator
 
     private static Dictionary<string, string> AppendParameters(
         OpenApiDocument document,
-        KeyValuePair<string, OpenApiPathItem> operationPath,
+        KeyValuePair<string, IOpenApiPathItem> operationPath,
         GeneratorSettings settings,
         OpenApiOperation operation,
         string verb,
@@ -429,10 +429,10 @@ public static class HttpFileGenerator
         // Merge path-level parameters with operation-level parameters.
         // Operation-level parameters override path-level ones with the same name+in.
         var pathLevelParams = operationPath.Value.Parameters
-            ?? Enumerable.Empty<OpenApiParameter>();
+            ?? Enumerable.Empty<IOpenApiParameter>();
 
         var operationParams = operation.Parameters
-            ?? Enumerable.Empty<OpenApiParameter>();
+            ?? Enumerable.Empty<IOpenApiParameter>();
 
         var parameters = pathLevelParams
             .Where(p => p is not null)
@@ -445,6 +445,7 @@ public static class HttpFileGenerator
         var parameterNameMap = new Dictionary<string, string>();
         foreach (var parameter in parameters)
         {
+            var parameterKey = parameter.Name ?? string.Empty;
             var parameterName = GetParameterName(
                 settings,
                 document,
@@ -453,7 +454,7 @@ public static class HttpFileGenerator
                 verb,
                 operationPath.Key,
                 parameter);
-            parameterNameMap[parameter.Name] = parameterName;
+            parameterNameMap[parameterKey] = parameterName;
 
             var defaultValue = GetParameterDefaultValue(parameter);
             
@@ -492,10 +493,10 @@ public static class HttpFileGenerator
         IOperationNameGenerator operationNameGenerator,
         string verb,
         string operationPathKey,
-        OpenApiParameter parameter)
+        IOpenApiParameter parameter)
     {
         if (settings.OutputType == OutputType.OneRequestPerFile)
-            return parameter.Name;
+            return parameter.Name ?? string.Empty;
 
         var name = operationNameGenerator.GetOperationName(
             document,
@@ -506,13 +507,14 @@ public static class HttpFileGenerator
         return $"{name}_{parameter.Name}";
     }
 
-    private static string GetParameterDefaultValue(OpenApiParameter parameter)
+    private static string GetParameterDefaultValue(IOpenApiParameter parameter)
     {
         // Get the schema from the parameter
         var schema = parameter.Schema;
-        if (schema?.Type != null)
+        var schemaType = GetSchemaType(schema);
+        if (schemaType is not null)
         {
-            return schema.Type.ToLowerInvariant() switch
+            return schemaType switch
             {
                 "integer" => "0",
                 "number" => "0",
@@ -523,7 +525,7 @@ public static class HttpFileGenerator
         return "str";
     }
 
-    private static string? GenerateSampleJson(OpenApiSchema? schema)
+    private static string? GenerateSampleJson(IOpenApiSchema? schema)
     {
         if (schema == null) return null;
 
@@ -547,7 +549,7 @@ public static class HttpFileGenerator
         }
 
         // Basic type-based JSON sample generation
-        return schema.Type?.ToLowerInvariant() switch
+        return GetSchemaType(schema) switch
         {
             "object" => "{\n  \"property\": \"value\"\n}",
             "array" => "[\n  \"item1\",\n  \"item2\"\n]",
@@ -559,7 +561,7 @@ public static class HttpFileGenerator
         };
     }
 
-    private static string GetPropertySampleValue(OpenApiSchema schema)
+    private static string GetPropertySampleValue(IOpenApiSchema? schema)
     {
         if (schema == null) return "\"value\"";
 
@@ -573,7 +575,7 @@ public static class HttpFileGenerator
         if (schema.AnyOf?.Count > 0)
             return GetPropertySampleValue(schema.AnyOf.FirstOrDefault(s => s != null) ?? schema);
 
-        return schema.Type?.ToLowerInvariant() switch
+        return GetSchemaType(schema) switch
         {
             "string" => "\"example\"",
             "integer" => "0",
@@ -583,5 +585,34 @@ public static class HttpFileGenerator
             "object" => "{\"property\": \"value\"}",
             _ => "\"value\""
         };
+    }
+
+    private static string? GetSchemaType(IOpenApiSchema? schema)
+    {
+        if (schema?.Type is null)
+            return null;
+
+        if (schema.Type.Value.HasFlag(JsonSchemaType.Integer))
+            return "integer";
+
+        if (schema.Type.Value.HasFlag(JsonSchemaType.Number))
+            return "number";
+
+        if (schema.Type.Value.HasFlag(JsonSchemaType.Boolean))
+            return "boolean";
+
+        if (schema.Type.Value.HasFlag(JsonSchemaType.Object))
+            return "object";
+
+        if (schema.Type.Value.HasFlag(JsonSchemaType.Array))
+            return "array";
+
+        if (schema.Type.Value.HasFlag(JsonSchemaType.String))
+            return "string";
+
+        if (schema.Type.Value.HasFlag(JsonSchemaType.Null))
+            return "null";
+
+        return null;
     }
 }

--- a/src/HttpGenerator.Core/HttpGenerator.Core.csproj
+++ b/src/HttpGenerator.Core/HttpGenerator.Core.csproj
@@ -14,8 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.6.28" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.28" />
+    <PackageReference Include="Microsoft.OpenApi" Version="3.4.0" />
+    <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.4.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.1" />
     <PackageReference Include="System.Text.Json" Version="10.0.5" />
   </ItemGroup>

--- a/src/HttpGenerator.Core/OpenApiDocumentFactory.cs
+++ b/src/HttpGenerator.Core/OpenApiDocumentFactory.cs
@@ -1,6 +1,8 @@
 ﻿using System.Net;
-using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Readers;
+using System.Security;
+using System.Text;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Reader;
 
 namespace HttpGenerator.Core;
 
@@ -15,84 +17,125 @@ public static class OpenApiDocumentFactory
     /// <returns>A new instance of the <see cref="OpenApiDocument"/> class.</returns>
     public static async Task<OpenApiDocument> CreateAsync(string openApiPath)
     {
+        using var httpClient = CreateHttpClient();
+        var content = await GetOpenApiContent(openApiPath, httpClient);
+        var settings = CreateReaderSettings(openApiPath);
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+        var result = await OpenApiDocument.LoadAsync(
+            stream,
+            GetFormat(openApiPath, content),
+            settings,
+            CancellationToken.None);
+
+        return result.Document ?? throw CreateOpenApiLoadException(openApiPath, result.Diagnostic);
+    }
+
+    private static OpenApiReaderSettings CreateReaderSettings(string openApiPath)
+    {
+        var settings = new OpenApiReaderSettings
+        {
+            BaseUrl = GetBaseUrl(openApiPath),
+        };
+
+        settings.AddYamlReader();
+        return settings;
+    }
+
+    private static async Task<string> GetOpenApiContent(
+        string openApiPath,
+        HttpClient httpClient)
+    {
         if (IsHttp(openApiPath))
         {
-            var content = await GetHttpContent(openApiPath);
-            return await ParseOpenApiContent(content);
+            try
+            {
+                return await httpClient.GetStringAsync(openApiPath);
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new InvalidOperationException($"Could not download the file at {openApiPath}", ex);
+            }
         }
-        else 
-        {
-            var content = File.ReadAllText(openApiPath);
-            return await ParseOpenApiContent(content);
-        }
-    }
 
-    private static async Task<OpenApiDocument> ParseOpenApiContent(string content)
-    {
-        // Try to parse with Microsoft.OpenApi first
         try
         {
-            using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(content));
-            var reader = new OpenApiStreamReader();
-            var result = await reader.ReadAsync(stream, CancellationToken.None);
-            return result.OpenApiDocument;
+            return File.ReadAllText(openApiPath);
         }
-        catch (Exception ex) when (ex.Message.Contains("3.1.0") || ex.Message.Contains("not supported"))
+        catch (Exception ex) when (ex is FileNotFoundException ||
+                                   ex is PathTooLongException ||
+                                   ex is DirectoryNotFoundException ||
+                                   ex is IOException ||
+                                   ex is UnauthorizedAccessException ||
+                                   ex is SecurityException ||
+                                   ex is NotSupportedException)
         {
-            // If OpenAPI 3.1 is detected, try to downgrade to 3.0 for parsing
-            var downgradedContent = DowngradeOpenApi31To30(content);
-            using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(downgradedContent));
-            var reader = new OpenApiStreamReader();
-            var result = await reader.ReadAsync(stream, CancellationToken.None);
-            return result.OpenApiDocument;
+            throw new InvalidOperationException($"Could not open the file at {openApiPath}", ex);
         }
     }
 
-    private static string DowngradeOpenApi31To30(string content)
+    private static HttpClient CreateHttpClient()
     {
-        // Simple downgrade strategy: replace 3.1.0 with 3.0.3 and remove unsupported 3.1 features
-        return content
-            .Replace("\"openapi\": \"3.1.0\"", "\"openapi\": \"3.0.3\"")
-            .Replace("openapi: 3.1.0", "openapi: 3.0.3")
-            .Replace("openapi: \"3.1.0\"", "openapi: \"3.0.3\"")
-            // Remove webhooks section which is 3.1 specific
-            .Replace("\"webhooks\":", "\"x-webhooks\":")
-            .Replace("webhooks:", "x-webhooks:");
+        var httpClientHandler = new HttpClientHandler
+        {
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+            ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true,
+            SslProtocols = System.Security.Authentication.SslProtocols.Tls12,
+        };
+
+        return new HttpClient(httpClientHandler);
     }
 
-    /// <summary>
-    /// Gets the content of the URI as a string and decompresses it if necessary. 
-    /// </summary>
-    /// <returns>The content of the HTTP request.</returns>
-    private static async Task<string> GetHttpContent(string openApiPath)
+    private static Uri GetBaseUrl(string openApiPath)
     {
-        var httpMessageHandler = new HttpClientHandler();
-        httpMessageHandler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
-        httpMessageHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
-        using var http = new HttpClient(httpMessageHandler);
-        var content = await http.GetStringAsync(openApiPath);
-        return content;
+        if (IsHttp(openApiPath))
+            return new Uri(openApiPath);
+
+        var directoryName = new FileInfo(openApiPath).DirectoryName;
+        if (directoryName is null)
+            throw new InvalidOperationException($"Could not determine the base path for {openApiPath}");
+
+        return new Uri(directoryName + Path.DirectorySeparatorChar, UriKind.Absolute);
     }
 
-    /// <summary>
-    /// Determines whether the specified path is an HTTP URL.
-    /// </summary>
-    /// <param name="path">The path to check.</param>
-    /// <returns>True if the path is an HTTP URL, otherwise false.</returns>
+    private static string GetFormat(
+        string openApiPath,
+        string content)
+    {
+        if (openApiPath.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            return "json";
+
+        if (openApiPath.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) ||
+            openApiPath.EndsWith(".yml", StringComparison.OrdinalIgnoreCase))
+        {
+            return "yaml";
+        }
+
+        var firstNonWhitespaceCharacter = content.FirstOrDefault(c => !char.IsWhiteSpace(c));
+        return firstNonWhitespaceCharacter is '{' or '['
+            ? "json"
+            : "yaml";
+    }
+
+    private static InvalidOperationException CreateOpenApiLoadException(
+        string openApiPath,
+        OpenApiDiagnostic? diagnostic)
+    {
+        if (diagnostic is not null && diagnostic.Errors.Count > 0)
+        {
+            var errors = string.Join(
+                Environment.NewLine,
+                diagnostic.Errors.Select(error => error.ToString()));
+
+            return new InvalidOperationException(
+                $"Could not parse the file at {openApiPath}{Environment.NewLine}{errors}");
+        }
+
+        return new InvalidOperationException($"Could not parse the file at {openApiPath}");
+    }
+
     private static bool IsHttp(string path)
     {
-        return path.StartsWith("http://", StringComparison.OrdinalIgnoreCase) || 
+        return path.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
                path.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// Determines whether the specified path is a YAML file.
-    /// </summary>
-    /// <param name="path">The path to check.</param>
-    /// <returns>True if the path is a YAML file, otherwise false.</returns>
-    private static bool IsYaml(string path)
-    {
-        return path.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) || 
-               path.EndsWith(".yml", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/HttpGenerator.Core/OperationNameGenerator.cs
+++ b/src/HttpGenerator.Core/OperationNameGenerator.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 
 namespace HttpGenerator.Core;
 
@@ -32,7 +32,7 @@ internal class OperationNameGenerator : IOperationNameGenerator
                 operationName = $"{httpMethod}_{path}";
             }
             
-            return operationName
+            return operationName!
                 .CapitalizeFirstCharacter()
                 .ConvertKebabCaseToPascalCase()
                 .ConvertRouteToCamelCase()

--- a/src/HttpGenerator.Tests/OpenApiDocumentFactoryTests.cs
+++ b/src/HttpGenerator.Tests/OpenApiDocumentFactoryTests.cs
@@ -29,4 +29,20 @@ public class OpenApiDocumentFactoryTests
             .Should()
             .NotBeNull();
     }
+
+    [Theory]
+    [InlineData("V31.non-oauth-scopes.json")]
+    [InlineData("V31.non-oauth-scopes.yaml")]
+    [InlineData("V31.webhook-example.json")]
+    [InlineData("V31.webhook-example.yaml")]
+    public async Task Create_From_File_Returns_NotNull_For_V31_Specs(string manifestResourceStreamName)
+    {
+        var swaggerFile = await TestFile.CreateSwaggerFile(
+            EmbeddedResources.GetStringFromEmbeddedResource(manifestResourceStreamName),
+            manifestResourceStreamName);
+
+        (await OpenApiDocumentFactory.CreateAsync(swaggerFile))
+            .Should()
+            .NotBeNull();
+    }
 }

--- a/src/HttpGenerator.Tests/OpenApiValidatorTests.cs
+++ b/src/HttpGenerator.Tests/OpenApiValidatorTests.cs
@@ -2,6 +2,8 @@ using Atc.Test;
 using FluentAssertions;
 using HttpGenerator.Tests.Resources;
 using HttpGenerator.Validation;
+using Microsoft.OpenApi;
+using HttpOpenApiValidator = HttpGenerator.Validation.OpenApiValidator;
 
 namespace HttpGenerator.Tests;
 
@@ -25,7 +27,7 @@ public class OpenApiValidatorTests
     {
         var json = EmbeddedResources.GetSwaggerPetstore(sample);
         var swaggerFile = await TestFile.CreateSwaggerFile(json, filename);
-        var result = await OpenApiValidator.Validate(swaggerFile);
+        var result = await HttpOpenApiValidator.Validate(swaggerFile);
         result.IsValid.Should().BeTrue();
     }
 
@@ -36,7 +38,7 @@ public class OpenApiValidatorTests
     [InlineData(HttpUrlPrefix + "petstore.yaml")]
     public async Task Should_Return_True_For_Remote_Files(string url)
     {
-        var result = await OpenApiValidator.Validate(url);
+        var result = await HttpOpenApiValidator.Validate(url);
         result.IsValid.Should().BeTrue();
     }
 
@@ -44,18 +46,33 @@ public class OpenApiValidatorTests
     [InlineData(HttpUrlPrefix)]
     public Task Should_Throw_For_Bad_Url(string url)
     {
-        return new Func<Task>(()=> OpenApiValidator.Validate(url))
+        return new Func<Task>(()=> HttpOpenApiValidator.Validate(url))
             .Should()
             .ThrowExactlyAsync<InvalidOperationException>();
     }
 
+    [Theory]
+    [InlineData("V31.non-oauth-scopes.json")]
+    [InlineData("V31.non-oauth-scopes.yaml")]
+    [InlineData("V31.webhook-example.json")]
+    [InlineData("V31.webhook-example.yaml")]
+    public async Task Should_Throw_For_V31_Specs(string manifestResourceStreamName)
+    {
+        var json = EmbeddedResources.GetStringFromEmbeddedResource(manifestResourceStreamName);
+        var swaggerFile = await TestFile.CreateSwaggerFile(json, manifestResourceStreamName);
+
+        await new Func<Task>(() => HttpOpenApiValidator.Validate(swaggerFile))
+            .Should()
+            .ThrowExactlyAsync<OpenApiUnsupportedSpecVersionException>();
+    }
+
     [Theory, AutoNSubstituteData]
-    public async Task Should_Throw_Exception(string json)
+    public async Task Should_Return_Invalid_Result_For_Invalid_OpenApi(string json)
     {
         var swaggerFile = await TestFile.CreateSwaggerFile(json, $"{Guid.NewGuid():N}.json");
-        await new Func<Task>(() => OpenApiValidator.Validate(swaggerFile))
-            .Should()
-            .ThrowAsync<Exception>();
+        var result = await HttpOpenApiValidator.Validate(swaggerFile);
+        result.IsValid.Should().BeFalse();
+        result.Diagnostics.Errors.Should().NotBeEmpty();
     }
 
     [Theory, AutoNSubstituteData]

--- a/src/HttpGenerator/GenerateCommand.cs
+++ b/src/HttpGenerator/GenerateCommand.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using Azure.Core.Diagnostics;
 using HttpGenerator.Core;
 using HttpGenerator.Validation;
-using Microsoft.OpenApi.Readers.Exceptions;
+using MicrosoftOpenApi = Microsoft.OpenApi;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -47,7 +47,7 @@ public class GenerateCommand : AsyncCommand<Settings>
             DisplaySuccess(stopwatch.Elapsed);
             return 0;
         }
-        catch (OpenApiUnsupportedSpecVersionException exception)
+        catch (MicrosoftOpenApi.OpenApiUnsupportedSpecVersionException exception)
         {
             AnsiConsole.MarkupLine($"{Crlf}[red]Error:{Crlf}{exception.Message}[/]");
             AnsiConsole.MarkupLine(

--- a/src/HttpGenerator/HttpGenerator.csproj
+++ b/src/HttpGenerator/HttpGenerator.csproj
@@ -15,8 +15,8 @@
     <ItemGroup>
         <PackageReference Include="Exceptionless" Version="6.1.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.23.0" />
-        <PackageReference Include="Microsoft.OpenApi.OData" Version="1.7.5" />
-        <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.28" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.4.0" />
+        <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.4.0" />
         <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
     </ItemGroup>

--- a/src/HttpGenerator/Validation/OpenApiStats.cs
+++ b/src/HttpGenerator/Validation/OpenApiStats.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Services;
+﻿using Microsoft.OpenApi;
 
 namespace HttpGenerator.Validation;
 
@@ -15,30 +14,30 @@ public class OpenApiStats : OpenApiVisitorBase
     public int LinkCount { get; set; } = 0;
     public int CallbackCount { get; set; } = 0;
 
-    public override void Visit(OpenApiParameter parameter)
+    public override void Visit(IOpenApiParameter parameter)
     {
         ParameterCount++;
     }
 
-    public override void Visit(OpenApiSchema schema)
+    public override void Visit(IOpenApiSchema schema)
     {
         SchemaCount++;
     }
 
 
-    public override void Visit(IDictionary<string, OpenApiHeader> headers)
+    public override void Visit(IDictionary<string, IOpenApiHeader> headers)
     {
         HeaderCount++;
     }
 
 
-    public override void Visit(OpenApiPathItem pathItem)
+    public override void Visit(IOpenApiPathItem pathItem)
     {
         PathItemCount++;
     }
 
 
-    public override void Visit(OpenApiRequestBody requestBody)
+    public override void Visit(IOpenApiRequestBody requestBody)
     {
         RequestBodyCount++;
     }
@@ -56,12 +55,12 @@ public class OpenApiStats : OpenApiVisitorBase
     }
 
 
-    public override void Visit(OpenApiLink link)
+    public override void Visit(IOpenApiLink link)
     {
         LinkCount++;
     }
 
-    public override void Visit(OpenApiCallback callback)
+    public override void Visit(IOpenApiCallback callback)
     {
         CallbackCount++;
     }

--- a/src/HttpGenerator/Validation/OpenApiValidationResult.cs
+++ b/src/HttpGenerator/Validation/OpenApiValidationResult.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.OpenApi.Readers;
+﻿using Microsoft.OpenApi.Reader;
 
 namespace HttpGenerator.Validation;
 

--- a/src/HttpGenerator/Validation/OpenApiValidator.cs
+++ b/src/HttpGenerator/Validation/OpenApiValidator.cs
@@ -1,7 +1,8 @@
 ﻿using System.Net;
 using System.Security;
-using Microsoft.OpenApi.Readers;
-using Microsoft.OpenApi.Services;
+using System.Text;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Reader;
 
 namespace HttpGenerator.Validation;
 
@@ -10,33 +11,30 @@ public static class OpenApiValidator
     public static async Task<OpenApiValidationResult> Validate(string openApiPath)
     {
         var result = await ParseOpenApi(openApiPath);
+        var diagnostics = result.Diagnostic ?? new OpenApiDiagnostic();
 
         var statsVisitor = new OpenApiStats();
-        var walker = new OpenApiWalker(statsVisitor);
-        walker.Walk(result.OpenApiDocument);
+        if (result.Document is not null)
+        {
+            var walker = new OpenApiWalker(statsVisitor);
+            walker.Walk(result.Document);
+        }
 
         return new(
-            result.OpenApiDiagnostic,
+            diagnostics,
             statsVisitor);
     }
 
-    private static async Task<Stream> GetStream(
+    private static async Task<string> GetOpenApiContent(
         string input,
+        HttpClient httpClient,
         CancellationToken cancellationToken)
     {
         if (input.StartsWith("http", StringComparison.OrdinalIgnoreCase))
         {
             try
             {
-                var httpClientHandler = new HttpClientHandler()
-                {
-                    SslProtocols = System.Security.Authentication.SslProtocols.Tls12,
-                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-                    ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
-                };
-                using var httpClient = new HttpClient(httpClientHandler);
-                httpClient.DefaultRequestVersion = HttpVersion.Version20;
-                return await httpClient.GetStreamAsync(input, cancellationToken);
+                return await httpClient.GetStringAsync(input, cancellationToken);
             }
             catch (HttpRequestException ex)
             {
@@ -46,8 +44,7 @@ public static class OpenApiValidator
 
         try
         {
-            var fileInput = new FileInfo(input);
-            return fileInput.OpenRead();
+            return await File.ReadAllTextAsync(input, cancellationToken);
         }
         catch (Exception ex) when (ex is FileNotFoundException ||
                                    ex is PathTooLongException ||
@@ -63,24 +60,88 @@ public static class OpenApiValidator
 
     private static async Task<ReadResult> ParseOpenApi(string openApiFile)
     {
-        Uri baseUrl;
-        if (openApiFile.StartsWith("http", StringComparison.OrdinalIgnoreCase))
-        {
-            baseUrl = new Uri(openApiFile);
-        }
-        else
-        {
-            var directoryName = new FileInfo(openApiFile).DirectoryName;
-            baseUrl = new Uri($"file://{directoryName}{Path.DirectorySeparatorChar}");
-        }
-        
+        using var httpClient = CreateHttpClient();
+        var content = await GetOpenApiContent(openApiFile, httpClient, CancellationToken.None);
         var openApiReaderSettings = new OpenApiReaderSettings
         {
-            BaseUrl = baseUrl
+            BaseUrl = GetBaseUrl(openApiFile),
         };
 
-        await using var stream = await GetStream(openApiFile, CancellationToken.None);
-        var reader = new OpenApiStreamReader(openApiReaderSettings);
-        return await reader.ReadAsync(stream, CancellationToken.None);
+        openApiReaderSettings.AddYamlReader();
+
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+        var result = await OpenApiDocument.LoadAsync(
+            stream,
+            GetFormat(openApiFile, content),
+            openApiReaderSettings,
+            CancellationToken.None);
+
+        ThrowIfUnsupported(result.Diagnostic);
+        return result;
+    }
+
+    private static void ThrowIfUnsupported(OpenApiDiagnostic? diagnostic)
+    {
+        if (diagnostic is null || diagnostic.SpecificationVersion <= OpenApiSpecVersion.OpenApi3_0)
+            return;
+
+        throw new OpenApiUnsupportedSpecVersionException(
+            $"OpenAPI specification version '{GetVersionText(diagnostic.SpecificationVersion)}' is not supported.");
+    }
+
+    private static string GetVersionText(OpenApiSpecVersion specificationVersion)
+    {
+        return specificationVersion switch
+        {
+            OpenApiSpecVersion.OpenApi3_1 => "3.1.0",
+            OpenApiSpecVersion.OpenApi3_2 => "3.2.0",
+            _ => specificationVersion.ToString(),
+        };
+    }
+
+    private static HttpClient CreateHttpClient()
+    {
+        var httpClientHandler = new HttpClientHandler
+        {
+            SslProtocols = System.Security.Authentication.SslProtocols.Tls12,
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+        };
+
+        return new HttpClient(httpClientHandler)
+        {
+            DefaultRequestVersion = HttpVersion.Version20,
+        };
+    }
+
+    private static Uri GetBaseUrl(string openApiFile)
+    {
+        if (openApiFile.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+            return new Uri(openApiFile);
+
+        var directoryName = new FileInfo(openApiFile).DirectoryName;
+        if (directoryName is null)
+            throw new InvalidOperationException($"Could not determine the base path for {openApiFile}");
+
+        return new Uri(directoryName + Path.DirectorySeparatorChar, UriKind.Absolute);
+    }
+
+    private static string GetFormat(
+        string openApiPath,
+        string content)
+    {
+        if (openApiPath.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            return "json";
+
+        if (openApiPath.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) ||
+            openApiPath.EndsWith(".yml", StringComparison.OrdinalIgnoreCase))
+        {
+            return "yaml";
+        }
+
+        var firstNonWhitespaceCharacter = content.FirstOrDefault(c => !char.IsWhiteSpace(c));
+        return firstNonWhitespaceCharacter is '{' or '['
+            ? "json"
+            : "yaml";
     }
 }


### PR DESCRIPTION
## Summary
- upgrade the OpenAPI reader pipeline to Microsoft.OpenApi 3.4.0 and Microsoft.OpenApi.YamlReader
- remove the unused Microsoft.OpenApi.OData package and update compile-critical OpenAPI usages to the new root namespaces and interfaces
- keep the existing CLI policy that OpenAPI 3.1+ still requires `--skip-validation`, while allowing document loading for skipped-validation generation paths

## Validation
- `dotnet restore HttpGenerator.sln`
- `dotnet build HttpGenerator.sln --configuration Release`
- targeted OpenAPI tests: local/V3.1-focused subset plus remote URI coverage
- `dotnet test HttpGenerator.sln --configuration Release --no-build`
- `dotnet run --project src\\HttpGenerator\\HttpGenerator.csproj --configuration Release --no-build -- test\\OpenAPI\\v3.0\\petstore.json --output <temp> --no-logging` (19 files generated)

## Deferred follow-up
- multi-type OpenAPI 3.1 schema sample-generation nuances are left for a later dependency milestone to keep deps-005 scoped

Closes #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Upgraded OpenAPI library dependencies to version 3.4.0 with native YAML parsing support.

* **Improvements**
  * Enhanced OpenAPI document processing with more robust parameter and schema handling.

* **Tests**
  * Extended test coverage for OpenAPI 3.1 specification validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->