### PR TITLE
[deps-005] Migrate OpenAPI reader pipeline

### DIFF
--- a/.squad/agents/hicks/history.md
+++ b/.squad/agents/hicks/history.md
@@ -81,3 +81,23 @@ HTTP File Generator generates `.http` files from OpenAPI specs. Core logic is in
 **Testing:** All 171 unit tests pass. Validated with petstore.json showing correct output for mixed param types:
 - Query only: `GET {{baseUrl}}/user/login?username={{username}}&password={{password}}`
 - Path + query: `POST {{baseUrl}}/pet/{{petId}}?name={{name}}&status={{status}}`
+
+### Issue #331 / deps-005: OpenAPI reader pipeline migration
+**Date:** 2026-03-20
+
+**Problem:** The repo still depended on `Microsoft.OpenApi.Readers` 1.x and an OpenAPI 3.1 downgrade hack. Moving to `Microsoft.OpenApi` 3.4.0 required the new `LoadAsync(...)` pipeline, explicit YAML reader registration, root-namespace types, and stricter interface/null handling while keeping the repo's current `--skip-validation` behavior intact.
+
+**Solution:** Updated the direct OpenAPI package references in `src\HttpGenerator\HttpGenerator.csproj` and `src\HttpGenerator.Core\HttpGenerator.Core.csproj`, removed the unused CLI-only `Microsoft.OpenApi.OData` reference after a repo-wide search found no code usage, and migrated:
+- `src\HttpGenerator.Core\OpenApiDocumentFactory.cs`
+- `src\HttpGenerator\Validation\OpenApiValidator.cs`
+- `src\HttpGenerator\Validation\OpenApiValidationResult.cs`
+- `src\HttpGenerator\Validation\OpenApiStats.cs`
+- `src\HttpGenerator.Core\HttpFileGenerator.cs`
+- `src\HttpGenerator.Core\OperationNameGenerator.cs`
+- `src\HttpGenerator\GenerateCommand.cs`
+
+The new reader path now uses `OpenApiDocument.LoadAsync(...)`, `ReadResult.Document`, and `ReadResult.Diagnostic`, adds `readerSettings.AddYamlReader()` before YAML parsing, detects `json` vs `yaml` explicitly for stream-based loads, and keeps validation rejecting OpenAPI 3.1 so `--skip-validation` remains the documented opt-in path for generation.
+
+**Pattern learned:** In OpenAPI.NET 3.4, the stream overload of `OpenApiDocument.LoadAsync(...)` needs an explicit format string and YAML support is not active until `OpenApiReaderSettings.AddYamlReader()` is called. For this repo, downloading bytes yourself and then using the stream overload is safer than relying on the `OpenApiReaderSettings.HttpClient` property during the migration. The OpenAPI v3 object model also shifts several hot paths to `IOpenApi*` interfaces and `JsonSchemaType`, so generation code needs light interface/nullability adaptation even when behavior should stay the same.
+
+**Testing:** `dotnet restore HttpGenerator.sln`, `dotnet build HttpGenerator.sln --configuration Release`, targeted `OpenApiDocumentFactoryTests` + `OpenApiValidatorTests` (19/19 passed), parameter regression tests (42/42 passed), `SwaggerPetstoreTests` (56/56 passed), `dotnet test HttpGenerator.sln --configuration Release --no-build --filter "FullyQualifiedName!~GenerateCommandTests"` (161/161 passed), OpenAPI 3.1 GenerateCommand validation subsets passed, and local plus remote petstore CLI generation both produced 19 `.http` files. The aggregate `GenerateCommandTests` full filter still hangs in this environment, so broader GenerateCommand coverage should be revisited in deps-007/deps-008.

--- a/.squad/decisions/inbox/hicks-deps-005-openapi-reader.md
+++ b/.squad/decisions/inbox/hicks-deps-005-openapi-reader.md
@@ -1,0 +1,21 @@
+# Hicks deps-005 — OpenAPI reader pipeline decisions
+
+**Date:** 2026-03-20  
+**Issue:** #331 (`deps-005`)
+
+## Decisions
+
+1. **Remove `Microsoft.OpenApi.OData` from the CLI project.**  
+   A repo-wide search found no production code references to OData types or APIs, so keeping the package would only increase migration scope and runtime surface without delivering functionality.
+
+2. **Preserve the current validation contract for OpenAPI 3.1.**  
+   Even though OpenAPI.NET 3.4 can parse 3.1 documents, `OpenApiValidator` continues to throw `OpenApiUnsupportedSpecVersionException("3.1.0")` after parsing so the existing `--skip-validation` guidance remains true until the CLI/docs reconciliation work in `deps-007`.
+
+3. **Use explicit byte loading plus the stream `LoadAsync(...)` overload instead of `OpenApiReaderSettings.HttpClient`.**  
+   During the migration, the `HttpClient` property path produced a runtime `MissingMethodException` in this repo. The stable path here is: download bytes with repo-owned `HttpClient`, detect `json` vs `yaml`, call `readerSettings.AddYamlReader()`, then load with `OpenApiDocument.LoadAsync(stream, format, settings, ...)`.
+
+## Why
+
+- Keeps `deps-005` scoped to the reader pipeline and compile/build stability.
+- Avoids a runtime-only API trap while restoring YAML support for both file and URL inputs.
+- Defers user-visible validation behavior changes to the later CLI reconciliation issue instead of mixing scope in the dependency migration branch.

--- a/.squad/skills/openapi-yamlreader-loadasync/SKILL.md
+++ b/.squad/skills/openapi-yamlreader-loadasync/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: "openapi-yamlreader-loadasync"
+description: "Migrate HTTP File Generator to OpenAPI.NET 3.4 LoadAsync plus Microsoft.OpenApi.YamlReader"
+domain: "dependencies"
+confidence: "high"
+source: "issue #331 / deps-005"
+---
+
+## Context
+
+Use this pattern when replacing `Microsoft.OpenApi.Readers` 1.x with `Microsoft.OpenApi` 3.4.x + `Microsoft.OpenApi.YamlReader` in this repo.
+
+## Patterns
+
+### Package scope
+
+- Replace direct `Microsoft.OpenApi.Readers` references with `Microsoft.OpenApi.YamlReader`.
+- Keep `Microsoft.OpenApi` pinned to the matching major/minor version (`3.4.0` here).
+- Search the repo before upgrading `Microsoft.OpenApi.OData`; if no code uses it, remove it instead of carrying extra migration surface.
+
+### Reader migration
+
+- Switch from `OpenApiStreamReader` to `OpenApiDocument.LoadAsync(...)`.
+- When you use the **stream** overload, always pass an explicit format string (`"json"` or `"yaml"`).
+- Use `ReadResult.Document` and `ReadResult.Diagnostic` instead of the older `OpenApiDocument` / `OpenApiDiagnostic` property names.
+- Call `readerSettings.AddYamlReader()` before loading YAML. Without that registration, YAML parses fail with `Format 'yaml' is not supported.`
+
+### Safe transport pattern
+
+- In this repo, do **not** rely on `OpenApiReaderSettings.HttpClient` during the migration path.
+- The stable pattern is:
+  1. Download bytes yourself with a repo-controlled `HttpClient`
+  2. Detect the format from file extension or first meaningful character
+  3. Wrap the bytes in a `MemoryStream`
+  4. Call `OpenApiDocument.LoadAsync(stream, format, settings, cancellationToken)`
+
+### Model-surface adaptation
+
+- Expect `IOpenApi*` interfaces in hot paths (`IOpenApiPathItem`, `IOpenApiParameter`, `IOpenApiSchema`, etc.).
+- `OpenApiSchema.Type` is now `JsonSchemaType?`, so generation code should map it explicitly instead of calling string methods directly.
+- Add null guards when moving old generation helpers onto the new interface-based surface.
+
+### Repo-specific behavior
+
+- Keep OpenAPI 3.1 validation failing unless the corresponding user-facing docs and tests are being updated in the same issue.
+- For this repo's staged dependency plan, parsing can support 3.1 while `OpenApiValidator` still throws `OpenApiUnsupportedSpecVersionException("3.1.0")` so `--skip-validation` remains accurate.
+
+## Validation
+
+- `dotnet restore HttpGenerator.sln`
+- `dotnet build HttpGenerator.sln --configuration Release`
+- `dotnet test HttpGenerator.sln --configuration Release --no-build --filter "FullyQualifiedName~OpenApiDocumentFactoryTests|FullyQualifiedName~OpenApiValidatorTests"`
+- `dotnet test HttpGenerator.sln --configuration Release --no-build --filter "FullyQualifiedName!~GenerateCommandTests"`
+- Local CLI check: `dotnet run --project src\HttpGenerator\HttpGenerator.csproj --configuration Release -- test\OpenAPI\v3.0\petstore.json --output <temp> --no-logging`
+
+## Anti-Patterns
+
+- Do not assume installing `Microsoft.OpenApi.YamlReader` automatically enables YAML for existing stream-based loads.
+- Do not call `ToLowerInvariant()` directly on `OpenApiSchema.Type`; it is no longer a string.
+- Do not change the repo's OpenAPI 3.1 validation contract implicitly in the same branch unless the wider CLI/docs fallout is part of scope.

--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -1,5 +1,6 @@
-﻿using System.Text;
-using Microsoft.OpenApi.Models;
+using System.Linq;
+using System.Text;
+using Microsoft.OpenApi;
 
 namespace HttpGenerator.Core;
 
@@ -243,7 +244,7 @@ public static class HttpFileGenerator
 
     private static string GenerateRequest(
         OpenApiDocument document,
-        KeyValuePair<string, OpenApiPathItem> operationPath,
+        KeyValuePair<string, IOpenApiPathItem> operationPath,
         IOperationNameGenerator operationNameGenerator,
         GeneratorSettings settings,
         string verb,
@@ -351,7 +352,7 @@ public static class HttpFileGenerator
 
     private static void AppendSummary(
         string verb,
-        KeyValuePair<string, OpenApiPathItem> kv,
+        KeyValuePair<string, IOpenApiPathItem> kv,
         OpenApiOperation operation,
         StringBuilder code)
     {
@@ -419,7 +420,7 @@ public static class HttpFileGenerator
 
     private static Dictionary<string, string> AppendParameters(
         OpenApiDocument document,
-        KeyValuePair<string, OpenApiPathItem> operationPath,
+        KeyValuePair<string, IOpenApiPathItem> operationPath,
         GeneratorSettings settings,
         OpenApiOperation operation,
         string verb,
@@ -429,10 +430,10 @@ public static class HttpFileGenerator
         // Merge path-level parameters with operation-level parameters.
         // Operation-level parameters override path-level ones with the same name+in.
         var pathLevelParams = operationPath.Value.Parameters
-            ?? Enumerable.Empty<OpenApiParameter>();
+            ?? Enumerable.Empty<IOpenApiParameter>();
 
         var operationParams = operation.Parameters
-            ?? Enumerable.Empty<OpenApiParameter>();
+            ?? Enumerable.Empty<IOpenApiParameter>();
 
         var parameters = pathLevelParams
             .Where(p => p is not null)
@@ -453,7 +454,8 @@ public static class HttpFileGenerator
                 verb,
                 operationPath.Key,
                 parameter);
-            parameterNameMap[parameter.Name] = parameterName;
+            var parameterKey = parameter.Name ?? parameterName;
+            parameterNameMap[parameterKey] = parameterName;
 
             var defaultValue = GetParameterDefaultValue(parameter);
             
@@ -492,10 +494,10 @@ public static class HttpFileGenerator
         IOperationNameGenerator operationNameGenerator,
         string verb,
         string operationPathKey,
-        OpenApiParameter parameter)
+        IOpenApiParameter parameter)
     {
         if (settings.OutputType == OutputType.OneRequestPerFile)
-            return parameter.Name;
+            return parameter.Name ?? "param";
 
         var name = operationNameGenerator.GetOperationName(
             document,
@@ -503,16 +505,15 @@ public static class HttpFileGenerator
             verb,
             operation);
 
-        return $"{name}_{parameter.Name}";
+        return $"{name}_{parameter.Name ?? "param"}";
     }
 
-    private static string GetParameterDefaultValue(OpenApiParameter parameter)
+    private static string GetParameterDefaultValue(IOpenApiParameter parameter)
     {
-        // Get the schema from the parameter
-        var schema = parameter.Schema;
-        if (schema?.Type != null)
+        var schemaType = GetSchemaType(parameter.Schema);
+        if (!string.IsNullOrWhiteSpace(schemaType))
         {
-            return schema.Type.ToLowerInvariant() switch
+            return schemaType switch
             {
                 "integer" => "0",
                 "number" => "0",
@@ -523,7 +524,7 @@ public static class HttpFileGenerator
         return "str";
     }
 
-    private static string? GenerateSampleJson(OpenApiSchema? schema)
+    private static string? GenerateSampleJson(IOpenApiSchema? schema)
     {
         if (schema == null) return null;
 
@@ -547,7 +548,7 @@ public static class HttpFileGenerator
         }
 
         // Basic type-based JSON sample generation
-        return schema.Type?.ToLowerInvariant() switch
+        return GetSchemaType(schema) switch
         {
             "object" => "{\n  \"property\": \"value\"\n}",
             "array" => "[\n  \"item1\",\n  \"item2\"\n]",
@@ -559,7 +560,7 @@ public static class HttpFileGenerator
         };
     }
 
-    private static string GetPropertySampleValue(OpenApiSchema schema)
+    private static string GetPropertySampleValue(IOpenApiSchema? schema)
     {
         if (schema == null) return "\"value\"";
 
@@ -573,7 +574,7 @@ public static class HttpFileGenerator
         if (schema.AnyOf?.Count > 0)
             return GetPropertySampleValue(schema.AnyOf.FirstOrDefault(s => s != null) ?? schema);
 
-        return schema.Type?.ToLowerInvariant() switch
+        return GetSchemaType(schema) switch
         {
             "string" => "\"example\"",
             "integer" => "0",
@@ -583,5 +584,20 @@ public static class HttpFileGenerator
             "object" => "{\"property\": \"value\"}",
             _ => "\"value\""
         };
+    }
+
+    private static string? GetSchemaType(IOpenApiSchema? schema)
+    {
+        if (schema?.Type is null)
+        {
+            return null;
+        }
+
+        return schema.Type.Value
+            .ToString()
+            .Split(',')
+            .Select(part => part.Trim())
+            .FirstOrDefault(part => !string.IsNullOrWhiteSpace(part))
+            ?.ToLowerInvariant();
     }
 }

--- a/src/HttpGenerator.Core/HttpGenerator.Core.csproj
+++ b/src/HttpGenerator.Core/HttpGenerator.Core.csproj
@@ -14,8 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.6.28" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.28" />
+    <PackageReference Include="Microsoft.OpenApi" Version="3.4.0" />
+    <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.4.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.1" />
     <PackageReference Include="System.Text.Json" Version="10.0.5" />
   </ItemGroup>

--- a/src/HttpGenerator.Core/OpenApiDocumentFactory.cs
+++ b/src/HttpGenerator.Core/OpenApiDocumentFactory.cs
@@ -1,6 +1,8 @@
-﻿using System.Net;
-using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Readers;
+using System.Linq;
+using System.Net;
+using System.Text;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Reader;
 
 namespace HttpGenerator.Core;
 
@@ -15,63 +17,40 @@ public static class OpenApiDocumentFactory
     /// <returns>A new instance of the <see cref="OpenApiDocument"/> class.</returns>
     public static async Task<OpenApiDocument> CreateAsync(string openApiPath)
     {
+        var baseUrl = GetBaseUrl(openApiPath);
+
         if (IsHttp(openApiPath))
         {
             var content = await GetHttpContent(openApiPath);
-            return await ParseOpenApiContent(content);
+            return await ParseOpenApiContent(content, GetFormat(openApiPath, content), baseUrl);
         }
-        else 
-        {
-            var content = File.ReadAllText(openApiPath);
-            return await ParseOpenApiContent(content);
-        }
+
+        var fileContent = File.ReadAllBytes(openApiPath);
+        return await ParseOpenApiContent(
+            fileContent,
+            GetFormat(openApiPath, fileContent),
+            baseUrl);
     }
 
-    private static async Task<OpenApiDocument> ParseOpenApiContent(string content)
+    private static async Task<OpenApiDocument> ParseOpenApiContent(
+        byte[] content,
+        string format,
+        Uri? baseUrl)
     {
-        // Try to parse with Microsoft.OpenApi first
-        try
+        using var stream = new MemoryStream(content);
+        var readerSettings = new OpenApiReaderSettings
         {
-            using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(content));
-            var reader = new OpenApiStreamReader();
-            var result = await reader.ReadAsync(stream, CancellationToken.None);
-            return result.OpenApiDocument;
-        }
-        catch (Exception ex) when (ex.Message.Contains("3.1.0") || ex.Message.Contains("not supported"))
-        {
-            // If OpenAPI 3.1 is detected, try to downgrade to 3.0 for parsing
-            var downgradedContent = DowngradeOpenApi31To30(content);
-            using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(downgradedContent));
-            var reader = new OpenApiStreamReader();
-            var result = await reader.ReadAsync(stream, CancellationToken.None);
-            return result.OpenApiDocument;
-        }
-    }
+            BaseUrl = baseUrl
+        };
+        readerSettings.AddYamlReader();
 
-    private static string DowngradeOpenApi31To30(string content)
-    {
-        // Simple downgrade strategy: replace 3.1.0 with 3.0.3 and remove unsupported 3.1 features
-        return content
-            .Replace("\"openapi\": \"3.1.0\"", "\"openapi\": \"3.0.3\"")
-            .Replace("openapi: 3.1.0", "openapi: 3.0.3")
-            .Replace("openapi: \"3.1.0\"", "openapi: \"3.0.3\"")
-            // Remove webhooks section which is 3.1 specific
-            .Replace("\"webhooks\":", "\"x-webhooks\":")
-            .Replace("webhooks:", "x-webhooks:");
-    }
+        var result = await OpenApiDocument.LoadAsync(
+            stream,
+            format,
+            readerSettings,
+            CancellationToken.None);
 
-    /// <summary>
-    /// Gets the content of the URI as a string and decompresses it if necessary. 
-    /// </summary>
-    /// <returns>The content of the HTTP request.</returns>
-    private static async Task<string> GetHttpContent(string openApiPath)
-    {
-        var httpMessageHandler = new HttpClientHandler();
-        httpMessageHandler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
-        httpMessageHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
-        using var http = new HttpClient(httpMessageHandler);
-        var content = await http.GetStringAsync(openApiPath);
-        return content;
+        return result.Document ?? throw CreateDocumentLoadException(result.Diagnostic);
     }
 
     /// <summary>
@@ -85,14 +64,89 @@ public static class OpenApiDocumentFactory
                path.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
     }
 
-    /// <summary>
-    /// Determines whether the specified path is a YAML file.
-    /// </summary>
-    /// <param name="path">The path to check.</param>
-    /// <returns>True if the path is a YAML file, otherwise false.</returns>
-    private static bool IsYaml(string path)
+    private static Uri? GetBaseUrl(string openApiPath)
     {
-        return path.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) || 
-               path.EndsWith(".yml", StringComparison.OrdinalIgnoreCase);
+        if (IsHttp(openApiPath))
+        {
+            return new Uri(openApiPath);
+        }
+
+        var directoryName = Path.GetDirectoryName(Path.GetFullPath(openApiPath));
+        if (string.IsNullOrWhiteSpace(directoryName))
+        {
+            return null;
+        }
+
+        var endsWithDirectorySeparator =
+            directoryName.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) ||
+            directoryName.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal);
+
+        var fullDirectoryPath = endsWithDirectorySeparator
+            ? directoryName
+            : directoryName + Path.DirectorySeparatorChar;
+
+        return new Uri(fullDirectoryPath);
+    }
+
+    private static async Task<byte[]> GetHttpContent(string openApiPath)
+    {
+        using var http = CreateHttpClient();
+        return await http.GetByteArrayAsync(openApiPath);
+    }
+
+    private static string GetFormat(string openApiPath, byte[] content)
+    {
+        var extension = Path.GetExtension(openApiPath);
+        if (extension.Equals(".yaml", StringComparison.OrdinalIgnoreCase) ||
+            extension.Equals(".yml", StringComparison.OrdinalIgnoreCase))
+        {
+            return "yaml";
+        }
+
+        if (extension.Equals(".json", StringComparison.OrdinalIgnoreCase))
+        {
+            return "json";
+        }
+
+        var text = Encoding.UTF8.GetString(content);
+        var firstMeaningfulCharacter = text
+            .SkipWhile(character => char.IsWhiteSpace(character) || character == '\uFEFF')
+            .FirstOrDefault();
+
+        return firstMeaningfulCharacter is '{' or '['
+            ? "json"
+            : "yaml";
+    }
+
+    private static HttpClient CreateHttpClient()
+    {
+        var httpMessageHandler = new HttpClientHandler
+        {
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+            ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true
+        };
+        return new HttpClient(httpMessageHandler);
+    }
+
+    private static InvalidOperationException CreateDocumentLoadException(OpenApiDiagnostic? diagnostic)
+    {
+        if (diagnostic is null)
+        {
+            return new InvalidOperationException("Could not parse the OpenAPI document.");
+        }
+
+        var messages = diagnostic.Errors
+            .Concat(diagnostic.Warnings)
+            .Select(error => error.ToString())
+            .Where(message => !string.IsNullOrWhiteSpace(message))
+            .ToArray();
+
+        if (messages.Length == 0)
+        {
+            return new InvalidOperationException("Could not parse the OpenAPI document.");
+        }
+
+        return new InvalidOperationException(
+            $"Could not parse the OpenAPI document.{Environment.NewLine}{string.Join(Environment.NewLine, messages)}");
     }
 }

--- a/src/HttpGenerator.Core/OperationNameGenerator.cs
+++ b/src/HttpGenerator.Core/OperationNameGenerator.cs
@@ -1,6 +1,6 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 
 namespace HttpGenerator.Core;
 
@@ -24,13 +24,9 @@ internal class OperationNameGenerator : IOperationNameGenerator
         try
         {
             // Try to use operationId first if available
-            var operationName = operation.OperationId;
-            
-            if (string.IsNullOrWhiteSpace(operationName))
-            {
-                // Fallback to generating from path and method
-                operationName = $"{httpMethod}_{path}";
-            }
+            var operationName = string.IsNullOrWhiteSpace(operation.OperationId)
+                ? $"{httpMethod}_{path}"
+                : operation.OperationId!;
             
             return operationName
                 .CapitalizeFirstCharacter()

--- a/src/HttpGenerator/GenerateCommand.cs
+++ b/src/HttpGenerator/GenerateCommand.cs
@@ -1,9 +1,9 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Azure.Core.Diagnostics;
 using HttpGenerator.Core;
 using HttpGenerator.Validation;
-using Microsoft.OpenApi.Readers.Exceptions;
+using OpenApiUnsupportedSpecVersionException = Microsoft.OpenApi.OpenApiUnsupportedSpecVersionException;
 using Spectre.Console;
 using Spectre.Console.Cli;
 

--- a/src/HttpGenerator/HttpGenerator.csproj
+++ b/src/HttpGenerator/HttpGenerator.csproj
@@ -15,8 +15,8 @@
     <ItemGroup>
         <PackageReference Include="Exceptionless" Version="6.1.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.23.0" />
-        <PackageReference Include="Microsoft.OpenApi.OData" Version="1.7.5" />
-        <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.28" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.4.0" />
+        <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.4.0" />
         <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
     </ItemGroup>

--- a/src/HttpGenerator/Validation/OpenApiStats.cs
+++ b/src/HttpGenerator/Validation/OpenApiStats.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Services;
+using Microsoft.OpenApi;
 
 namespace HttpGenerator.Validation;
 
@@ -15,30 +14,30 @@ public class OpenApiStats : OpenApiVisitorBase
     public int LinkCount { get; set; } = 0;
     public int CallbackCount { get; set; } = 0;
 
-    public override void Visit(OpenApiParameter parameter)
+    public override void Visit(IOpenApiParameter parameter)
     {
         ParameterCount++;
     }
 
-    public override void Visit(OpenApiSchema schema)
+    public override void Visit(IOpenApiSchema schema)
     {
         SchemaCount++;
     }
 
 
-    public override void Visit(IDictionary<string, OpenApiHeader> headers)
+    public override void Visit(IDictionary<string, IOpenApiHeader> headers)
     {
         HeaderCount++;
     }
 
 
-    public override void Visit(OpenApiPathItem pathItem)
+    public override void Visit(IOpenApiPathItem pathItem)
     {
         PathItemCount++;
     }
 
 
-    public override void Visit(OpenApiRequestBody requestBody)
+    public override void Visit(IOpenApiRequestBody requestBody)
     {
         RequestBodyCount++;
     }
@@ -56,12 +55,12 @@ public class OpenApiStats : OpenApiVisitorBase
     }
 
 
-    public override void Visit(OpenApiLink link)
+    public override void Visit(IOpenApiLink link)
     {
         LinkCount++;
     }
 
-    public override void Visit(OpenApiCallback callback)
+    public override void Visit(IOpenApiCallback callback)
     {
         CallbackCount++;
     }

--- a/src/HttpGenerator/Validation/OpenApiValidationResult.cs
+++ b/src/HttpGenerator/Validation/OpenApiValidationResult.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.OpenApi.Readers;
+using Microsoft.OpenApi.Reader;
 
 namespace HttpGenerator.Validation;
 

--- a/src/HttpGenerator/Validation/OpenApiValidator.cs
+++ b/src/HttpGenerator/Validation/OpenApiValidator.cs
@@ -1,7 +1,9 @@
-﻿using System.Net;
+using System.Linq;
+using System.Net;
 using System.Security;
-using Microsoft.OpenApi.Readers;
-using Microsoft.OpenApi.Services;
+using System.Text;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Reader;
 
 namespace HttpGenerator.Validation;
 
@@ -13,41 +15,50 @@ public static class OpenApiValidator
 
         var statsVisitor = new OpenApiStats();
         var walker = new OpenApiWalker(statsVisitor);
-        walker.Walk(result.OpenApiDocument);
+        walker.Walk(result.Document);
 
         return new(
-            result.OpenApiDiagnostic,
+            result.Diagnostic ?? new OpenApiDiagnostic(),
             statsVisitor);
     }
 
-    private static async Task<Stream> GetStream(
-        string input,
-        CancellationToken cancellationToken)
+    private static OpenApiReaderSettings CreateReaderSettings(string input)
     {
-        if (input.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+        var settings = new OpenApiReaderSettings
         {
-            try
-            {
-                var httpClientHandler = new HttpClientHandler()
-                {
-                    SslProtocols = System.Security.Authentication.SslProtocols.Tls12,
-                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-                    ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
-                };
-                using var httpClient = new HttpClient(httpClientHandler);
-                httpClient.DefaultRequestVersion = HttpVersion.Version20;
-                return await httpClient.GetStreamAsync(input, cancellationToken);
-            }
-            catch (HttpRequestException ex)
-            {
-                throw new InvalidOperationException($"Could not download the file at {input}", ex);
-            }
-        }
+            BaseUrl = GetBaseUrl(input)
+        };
+        settings.AddYamlReader();
+        return settings;
+    }
 
+    private static async Task<ReadResult> ParseOpenApi(string openApiFile)
+    {
         try
         {
-            var fileInput = new FileInfo(input);
-            return fileInput.OpenRead();
+            var content = await GetContent(openApiFile);
+            using var stream = new MemoryStream(content);
+            var result = await OpenApiDocument.LoadAsync(
+                stream,
+                GetFormat(openApiFile, content),
+                CreateReaderSettings(openApiFile),
+                CancellationToken.None);
+
+            if (result.Diagnostic?.SpecificationVersion == OpenApiSpecVersion.OpenApi3_1)
+            {
+                throw new OpenApiUnsupportedSpecVersionException("3.1.0");
+            }
+
+            if (result.Document is null)
+            {
+                throw CreateDocumentLoadException(openApiFile, result.Diagnostic);
+            }
+
+            return result;
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new InvalidOperationException($"Could not download the file at {openApiFile}", ex);
         }
         catch (Exception ex) when (ex is FileNotFoundException ||
                                    ex is PathTooLongException ||
@@ -57,30 +68,99 @@ public static class OpenApiValidator
                                    ex is SecurityException ||
                                    ex is NotSupportedException)
         {
-            throw new InvalidOperationException($"Could not open the file at {input}", ex);
+            throw new InvalidOperationException($"Could not open the file at {openApiFile}", ex);
         }
     }
 
-    private static async Task<ReadResult> ParseOpenApi(string openApiFile)
+    private static async Task<byte[]> GetContent(string input)
     {
-        Uri baseUrl;
+        if (input.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+        {
+            using var httpClient = CreateHttpClient();
+            return await httpClient.GetByteArrayAsync(input);
+        }
+
+        return File.ReadAllBytes(input);
+    }
+
+    private static InvalidOperationException CreateDocumentLoadException(
+        string openApiFile,
+        OpenApiDiagnostic? diagnostic)
+    {
+        var messages = diagnostic?.Errors
+            .Concat(diagnostic.Warnings ?? Array.Empty<OpenApiError>())
+            .Select(error => error.ToString())
+            .Where(message => !string.IsNullOrWhiteSpace(message))
+            .ToArray() ?? Array.Empty<string>();
+
+        if (messages.Length == 0)
+        {
+            return new InvalidOperationException($"Could not parse the OpenAPI document at {openApiFile}");
+        }
+
+        return new InvalidOperationException(
+            $"Could not parse the OpenAPI document at {openApiFile}{Environment.NewLine}{string.Join(Environment.NewLine, messages)}");
+    }
+
+    private static Uri? GetBaseUrl(string openApiFile)
+    {
         if (openApiFile.StartsWith("http", StringComparison.OrdinalIgnoreCase))
         {
-            baseUrl = new Uri(openApiFile);
+            return new Uri(openApiFile);
         }
-        else
-        {
-            var directoryName = new FileInfo(openApiFile).DirectoryName;
-            baseUrl = new Uri($"file://{directoryName}{Path.DirectorySeparatorChar}");
-        }
-        
-        var openApiReaderSettings = new OpenApiReaderSettings
-        {
-            BaseUrl = baseUrl
-        };
 
-        await using var stream = await GetStream(openApiFile, CancellationToken.None);
-        var reader = new OpenApiStreamReader(openApiReaderSettings);
-        return await reader.ReadAsync(stream, CancellationToken.None);
+        var directoryName = Path.GetDirectoryName(Path.GetFullPath(openApiFile));
+        if (string.IsNullOrWhiteSpace(directoryName))
+        {
+            return null;
+        }
+
+        var endsWithDirectorySeparator =
+            directoryName.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) ||
+            directoryName.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal);
+
+        var fullDirectoryPath = endsWithDirectorySeparator
+            ? directoryName
+            : directoryName + Path.DirectorySeparatorChar;
+
+        return new Uri(fullDirectoryPath);
+    }
+
+    private static HttpClient CreateHttpClient()
+    {
+        var httpClientHandler = new HttpClientHandler
+        {
+            SslProtocols = System.Security.Authentication.SslProtocols.Tls12,
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+        };
+        return new HttpClient(httpClientHandler)
+        {
+            DefaultRequestVersion = HttpVersion.Version20
+        };
+    }
+
+    private static string GetFormat(string openApiFile, byte[] content)
+    {
+        var extension = Path.GetExtension(openApiFile);
+        if (extension.Equals(".yaml", StringComparison.OrdinalIgnoreCase) ||
+            extension.Equals(".yml", StringComparison.OrdinalIgnoreCase))
+        {
+            return "yaml";
+        }
+
+        if (extension.Equals(".json", StringComparison.OrdinalIgnoreCase))
+        {
+            return "json";
+        }
+
+        var text = Encoding.UTF8.GetString(content);
+        var firstMeaningfulCharacter = text
+            .SkipWhile(character => char.IsWhiteSpace(character) || character == '\uFEFF')
+            .FirstOrDefault();
+
+        return firstMeaningfulCharacter is '{' or '['
+            ? "json"
+            : "yaml";
     }
 }


### PR DESCRIPTION
## Summary
- replace `Microsoft.OpenApi.Readers` with `Microsoft.OpenApi.YamlReader` and upgrade `Microsoft.OpenApi` to `3.4.0`
- remove unused `Microsoft.OpenApi.OData` from the CLI project and migrate the reader/validator pipeline to `OpenApiDocument.LoadAsync(...)`
- update generator/validation hot paths for root-namespace types, `IOpenApi*` interfaces, explicit YAML registration, and stricter null handling while preserving current OpenAPI 3.1 validation behavior

## Validation
- `dotnet build HttpGenerator.sln --configuration Release`
- `dotnet test HttpGenerator.sln --configuration Release --no-build --filter "FullyQualifiedName~OpenApiDocumentFactoryTests|FullyQualifiedName~OpenApiValidatorTests"`
- `dotnet test HttpGenerator.sln --configuration Release --no-build --filter "FullyQualifiedName!~GenerateCommandTests"`
- local petstore CLI generation: 19 files
- remote petstore CLI generation: 19 files

## Deferred fallout
- full aggregated `GenerateCommandTests` still hang in this environment even though the high-value GenerateCommand subsets and manual CLI checks pass; revisit in `deps-007` / `deps-008`
- broader visitor/stat traversal cleanup beyond the compile-critical path remains part of `deps-006`

Refs #331