### PR TITLE
docs: capture Atc.Test upgrade learnings

### DIFF
--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -41,3 +41,10 @@ Fixed 4 failing tests in `PathLevelParametersTests.cs` that had incorrect expect
 - **Test results:** All 13 PathLevelParametersTests pass, full suite: 184 tests pass
 - **PR:** https://github.com/christianhelle/httpgenerator/pull/323
 
+### Atc.Test v2 upgrade with pinned FluentAssertions (2026-03-20)
+
+- `Atc.Test` `2.0.17` keeps working in `src/HttpGenerator.Tests/HttpGenerator.Tests.csproj` while the repo pins `FluentAssertions` at `7.2.0`, but the test project must suppress `NU1605` because upstream now asks for `FluentAssertions >= 7.2.1`.
+- The package is now xUnit v3-only, so `src/HttpGenerator.Tests/HttpGenerator.Tests.csproj` must reference `xunit.v3`; current `origin/main` already carries the matching project settings for that move.
+- `src/HttpGenerator.Tests/GenerateCommandTests.cs` must pass `TestContext.Current.CancellationToken` into `GenerateCommand.ExecuteAsync(...)` to satisfy xUnit analyzer rule `xUnit1051`.
+- Validation signal for the refreshed stack stays `204/204` green via `dotnet restore HttpGenerator.sln`, `dotnet build HttpGenerator.sln --configuration Release`, and `dotnet test HttpGenerator.sln --configuration Release`.
+

--- a/.squad/skills/atc-test-v2-upgrade/SKILL.md
+++ b/.squad/skills/atc-test-v2-upgrade/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Atc.Test v2 Upgrade
+
+**Owner:** Bishop (Tester)  
+**Context:** HTTP File Generator test-project dependency refreshes involving `Atc.Test` 2.x  
+**Last Updated:** 2026-03-20
+
+---
+
+## What This Skill Does
+
+Captures the repo-specific steps for upgrading `Atc.Test` from the 1.x line to `2.0.17` without moving the suite off the pinned `FluentAssertions` 7.2.0 reference.
+
+---
+
+## Core Rules
+
+1. Keep `FluentAssertions` pinned at `7.2.0` in `src/HttpGenerator.Tests/HttpGenerator.Tests.csproj`.
+2. Suppress `NU1605` in that test project because `Atc.Test` 2.x transitively requests `FluentAssertions >= 7.2.1`.
+3. Replace the direct `xunit` package reference with `xunit.v3` because `Atc.Test` 2.x is built on xUnit v3 extensibility APIs.
+4. Fix xUnit v3 analyzer violations instead of suppressing them; in this repo that means passing `TestContext.Current.CancellationToken` into `GenerateCommand.ExecuteAsync(...)`.
+
+---
+
+## Validation
+
+Run:
+
+```powershell
+dotnet restore HttpGenerator.sln
+dotnet build HttpGenerator.sln --configuration Release
+dotnet test HttpGenerator.sln --configuration Release
+```
+
+Expected result for this repo:
+
+- Restore succeeds with the pinned `FluentAssertions` reference still present
+- Release build succeeds
+- `204/204` tests pass
+
+---
+
+## Key Files
+
+- `src/HttpGenerator.Tests/HttpGenerator.Tests.csproj`
+- `src/HttpGenerator.Tests/GenerateCommandTests.cs`


### PR DESCRIPTION
## Summary
- record Bishop's learnings from the Atc.Test 2.x refresh
- add a reusable squad skill for future Atc.Test v2 upgrades with pinned FluentAssertions
- note the xUnit v3 and cancellation-token adjustments that were required for #330

## Validation
- dotnet restore HttpGenerator.sln
- dotnet build HttpGenerator.sln --configuration Release
- dotnet test HttpGenerator.sln --configuration Release

Refs #330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added historical record documenting recent testing infrastructure compatibility updates and version management
* Added procedural guide for managing test dependency upgrades and validation steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->