### PR TITLE
deps-005: migrate OpenAPI reader pipeline

### DIFF
--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 
 namespace HttpGenerator.Core;
 
@@ -243,7 +243,7 @@ public static class HttpFileGenerator
 
     private static string GenerateRequest(
         OpenApiDocument document,
-        KeyValuePair<string, OpenApiPathItem> operationPath,
+        KeyValuePair<string, IOpenApiPathItem> operationPath,
         IOperationNameGenerator operationNameGenerator,
         GeneratorSettings settings,
         string verb,
@@ -351,7 +351,7 @@ public static class HttpFileGenerator
 
     private static void AppendSummary(
         string verb,
-        KeyValuePair<string, OpenApiPathItem> kv,
+        KeyValuePair<string, IOpenApiPathItem> kv,
         OpenApiOperation operation,
         StringBuilder code)
     {
@@ -419,7 +419,7 @@ public static class HttpFileGenerator
 
     private static Dictionary<string, string> AppendParameters(
         OpenApiDocument document,
-        KeyValuePair<string, OpenApiPathItem> operationPath,
+        KeyValuePair<string, IOpenApiPathItem> operationPath,
         GeneratorSettings settings,
         OpenApiOperation operation,
         string verb,
@@ -429,14 +429,15 @@ public static class HttpFileGenerator
         // Merge path-level parameters with operation-level parameters.
         // Operation-level parameters override path-level ones with the same name+in.
         var pathLevelParams = operationPath.Value.Parameters
-            ?? Enumerable.Empty<OpenApiParameter>();
+            ?? Enumerable.Empty<IOpenApiParameter>();
 
         var operationParams = operation.Parameters
-            ?? Enumerable.Empty<OpenApiParameter>();
+            ?? Enumerable.Empty<IOpenApiParameter>();
 
         var parameters = pathLevelParams
+            .Concat(operationParams)
             .Where(p => p is not null)
-            .Concat(operationParams.Where(p => p is not null))
+            .Select(p => p!)
             .GroupBy(p => (p.Name, p.In))
             .Select(g => g.Last()) // operation-level wins (it's appended last)
             .Where(p => p.In == ParameterLocation.Path || p.In == ParameterLocation.Query)
@@ -445,6 +446,7 @@ public static class HttpFileGenerator
         var parameterNameMap = new Dictionary<string, string>();
         foreach (var parameter in parameters)
         {
+            var parameterKey = parameter.Name ?? string.Empty;
             var parameterName = GetParameterName(
                 settings,
                 document,
@@ -453,7 +455,7 @@ public static class HttpFileGenerator
                 verb,
                 operationPath.Key,
                 parameter);
-            parameterNameMap[parameter.Name] = parameterName;
+            parameterNameMap[parameterKey] = parameterName;
 
             var defaultValue = GetParameterDefaultValue(parameter);
             
@@ -492,10 +494,10 @@ public static class HttpFileGenerator
         IOperationNameGenerator operationNameGenerator,
         string verb,
         string operationPathKey,
-        OpenApiParameter parameter)
+        IOpenApiParameter parameter)
     {
         if (settings.OutputType == OutputType.OneRequestPerFile)
-            return parameter.Name;
+            return parameter.Name ?? string.Empty;
 
         var name = operationNameGenerator.GetOperationName(
             document,
@@ -506,24 +508,23 @@ public static class HttpFileGenerator
         return $"{name}_{parameter.Name}";
     }
 
-    private static string GetParameterDefaultValue(OpenApiParameter parameter)
+    private static string GetParameterDefaultValue(IOpenApiParameter parameter)
     {
         // Get the schema from the parameter
         var schema = parameter.Schema;
         if (schema?.Type != null)
         {
-            return schema.Type.ToLowerInvariant() switch
-            {
-                "integer" => "0",
-                "number" => "0",
-                "boolean" => "true",
-                _ => "str"
-            };
+            var schemaType = schema.Type.Value;
+            if (schemaType.HasFlag(JsonSchemaType.Integer) || schemaType.HasFlag(JsonSchemaType.Number))
+                return "0";
+            if (schemaType.HasFlag(JsonSchemaType.Boolean))
+                return "true";
+            return "str";
         }
         return "str";
     }
 
-    private static string? GenerateSampleJson(OpenApiSchema? schema)
+    private static string? GenerateSampleJson(IOpenApiSchema? schema)
     {
         if (schema == null) return null;
 
@@ -547,19 +548,26 @@ public static class HttpFileGenerator
         }
 
         // Basic type-based JSON sample generation
-        return schema.Type?.ToLowerInvariant() switch
+        var schemaType = schema.Type;
+        if (schemaType.HasValue)
         {
-            "object" => "{\n  \"property\": \"value\"\n}",
-            "array" => "[\n  \"item1\",\n  \"item2\"\n]",
-            "string" => "\"example\"",
-            "integer" => "0",
-            "number" => "0",
-            "boolean" => "true",
-            _ => "{}"
-        };
+            if (schemaType.Value.HasFlag(JsonSchemaType.Object))
+                return "{\n  \"property\": \"value\"\n}";
+            if (schemaType.Value.HasFlag(JsonSchemaType.Array))
+                return "[\n  \"item1\",\n  \"item2\"\n]";
+            if (schemaType.Value.HasFlag(JsonSchemaType.String))
+                return "\"example\"";
+            if (schemaType.Value.HasFlag(JsonSchemaType.Integer))
+                return "0";
+            if (schemaType.Value.HasFlag(JsonSchemaType.Number))
+                return "0";
+            if (schemaType.Value.HasFlag(JsonSchemaType.Boolean))
+                return "true";
+        }
+        return "{}";
     }
 
-    private static string GetPropertySampleValue(OpenApiSchema schema)
+    private static string GetPropertySampleValue(IOpenApiSchema schema)
     {
         if (schema == null) return "\"value\"";
 
@@ -573,15 +581,22 @@ public static class HttpFileGenerator
         if (schema.AnyOf?.Count > 0)
             return GetPropertySampleValue(schema.AnyOf.FirstOrDefault(s => s != null) ?? schema);
 
-        return schema.Type?.ToLowerInvariant() switch
+        var schemaType = schema.Type;
+        if (schemaType.HasValue)
         {
-            "string" => "\"example\"",
-            "integer" => "0",
-            "number" => "0.0",
-            "boolean" => "true",
-            "array" => "[\"item\"]",
-            "object" => "{\"property\": \"value\"}",
-            _ => "\"value\""
-        };
+            if (schemaType.Value.HasFlag(JsonSchemaType.String))
+                return "\"example\"";
+            if (schemaType.Value.HasFlag(JsonSchemaType.Integer))
+                return "0";
+            if (schemaType.Value.HasFlag(JsonSchemaType.Number))
+                return "0.0";
+            if (schemaType.Value.HasFlag(JsonSchemaType.Boolean))
+                return "true";
+            if (schemaType.Value.HasFlag(JsonSchemaType.Array))
+                return "[\"item\"]";
+            if (schemaType.Value.HasFlag(JsonSchemaType.Object))
+                return "{\"property\": \"value\"}";
+        }
+        return "\"value\"";
     }
 }

--- a/src/HttpGenerator.Core/HttpGenerator.Core.csproj
+++ b/src/HttpGenerator.Core/HttpGenerator.Core.csproj
@@ -14,8 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.6.28" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.28" />
+    <PackageReference Include="Microsoft.OpenApi" Version="3.4.0" />
+    <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.4.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.1" />
     <PackageReference Include="System.Text.Json" Version="10.0.5" />
   </ItemGroup>

--- a/src/HttpGenerator.Core/OpenApiDocumentFactory.cs
+++ b/src/HttpGenerator.Core/OpenApiDocumentFactory.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net;
-using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Readers;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Reader;
 
 namespace HttpGenerator.Core;
 
@@ -18,34 +18,83 @@ public static class OpenApiDocumentFactory
         if (IsHttp(openApiPath))
         {
             var content = await GetHttpContent(openApiPath);
-            return await ParseOpenApiContent(content);
+            return await ParseOpenApiContent(content, openApiPath);
         }
         else 
         {
             var content = File.ReadAllText(openApiPath);
-            return await ParseOpenApiContent(content);
+            return await ParseOpenApiContent(content, openApiPath);
         }
     }
 
-    private static async Task<OpenApiDocument> ParseOpenApiContent(string content)
+    private static async Task<OpenApiDocument> ParseOpenApiContent(string content, string openApiPath)
     {
         // Try to parse with Microsoft.OpenApi first
         try
         {
             using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(content));
-            var reader = new OpenApiStreamReader();
-            var result = await reader.ReadAsync(stream, CancellationToken.None);
-            return result.OpenApiDocument;
+            var settings = CreateReaderSettings(openApiPath);
+            var format = GetFormat(openApiPath, content);
+            var result = await OpenApiDocument.LoadAsync(
+                stream,
+                format,
+                settings,
+                CancellationToken.None);
+            return GetDocument(result, openApiPath);
         }
-        catch (Exception ex) when (ex.Message.Contains("3.1.0") || ex.Message.Contains("not supported"))
+        catch (OpenApiUnsupportedSpecVersionException ex)
+            when (ex.Message.Contains("3.1.0") || ex.Message.Contains("not supported"))
         {
             // If OpenAPI 3.1 is detected, try to downgrade to 3.0 for parsing
             var downgradedContent = DowngradeOpenApi31To30(content);
             using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(downgradedContent));
-            var reader = new OpenApiStreamReader();
-            var result = await reader.ReadAsync(stream, CancellationToken.None);
-            return result.OpenApiDocument;
+            var settings = CreateReaderSettings(openApiPath);
+            var format = GetFormat(openApiPath, downgradedContent);
+            var result = await OpenApiDocument.LoadAsync(
+                stream,
+                format,
+                settings,
+                CancellationToken.None);
+            return GetDocument(result, openApiPath);
         }
+    }
+
+    private static OpenApiDocument GetDocument(ReadResult result, string openApiPath)
+    {
+        return result.Document ?? throw new InvalidOperationException(
+            $"OpenAPI document could not be parsed from {openApiPath}.");
+    }
+
+    private static OpenApiReaderSettings CreateReaderSettings(string openApiPath)
+    {
+        var settings = new OpenApiReaderSettings
+        {
+            BaseUrl = GetBaseUrl(openApiPath)
+        };
+        settings.AddYamlReader();
+        return settings;
+    }
+
+    private static Uri GetBaseUrl(string openApiPath)
+    {
+        if (IsHttp(openApiPath))
+        {
+            return new Uri(openApiPath);
+        }
+
+        var directoryName = new FileInfo(openApiPath).DirectoryName;
+        return new Uri($"file://{directoryName}{Path.DirectorySeparatorChar}");
+    }
+
+    private static string GetFormat(string openApiPath, string content)
+    {
+        if (IsYaml(openApiPath))
+            return "yaml";
+
+        var trimmed = content.AsSpan().TrimStart();
+        return trimmed.StartsWith("{") || trimmed.StartsWith("[")
+            ? "json"
+            : "yaml";
     }
 
     private static string DowngradeOpenApi31To30(string content)
@@ -66,9 +115,10 @@ public static class OpenApiDocumentFactory
     /// <returns>The content of the HTTP request.</returns>
     private static async Task<string> GetHttpContent(string openApiPath)
     {
-        var httpMessageHandler = new HttpClientHandler();
-        httpMessageHandler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
-        httpMessageHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
+        var httpMessageHandler = new HttpClientHandler
+        {
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+        };
         using var http = new HttpClient(httpMessageHandler);
         var content = await http.GetStringAsync(openApiPath);
         return content;

--- a/src/HttpGenerator.Core/OperationNameGenerator.cs
+++ b/src/HttpGenerator.Core/OperationNameGenerator.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 
 namespace HttpGenerator.Core;
 
@@ -32,7 +32,7 @@ internal class OperationNameGenerator : IOperationNameGenerator
                 operationName = $"{httpMethod}_{path}";
             }
             
-            return operationName
+            return (operationName ?? string.Empty)
                 .CapitalizeFirstCharacter()
                 .ConvertKebabCaseToPascalCase()
                 .ConvertRouteToCamelCase()

--- a/src/HttpGenerator/GenerateCommand.cs
+++ b/src/HttpGenerator/GenerateCommand.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using Azure.Core.Diagnostics;
 using HttpGenerator.Core;
 using HttpGenerator.Validation;
-using Microsoft.OpenApi.Readers.Exceptions;
+using Microsoft.OpenApi;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -140,7 +140,7 @@ public class GenerateCommand : AsyncCommand<Settings>
     private static async Task ValidateOpenApiSpec(Settings settings)
     {
         AnsiConsole.MarkupLine("[cyan]🔍 Validating OpenAPI specification...[/]");
-        var validationResult = await OpenApiValidator.Validate(settings.OpenApiPath!);
+        var validationResult = await Validation.OpenApiValidator.Validate(settings.OpenApiPath!);
         WriteValidationResults(validationResult);
         validationResult.ThrowIfInvalid();
 

--- a/src/HttpGenerator/HttpGenerator.csproj
+++ b/src/HttpGenerator/HttpGenerator.csproj
@@ -15,8 +15,8 @@
     <ItemGroup>
         <PackageReference Include="Exceptionless" Version="6.1.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.23.0" />
-        <PackageReference Include="Microsoft.OpenApi.OData" Version="1.7.5" />
-        <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.28" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.4.0" />
+        <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.4.0" />
         <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
     </ItemGroup>

--- a/src/HttpGenerator/Validation/OpenApiStats.cs
+++ b/src/HttpGenerator/Validation/OpenApiStats.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Services;
+﻿using Microsoft.OpenApi;
 
 namespace HttpGenerator.Validation;
 
@@ -15,30 +14,30 @@ public class OpenApiStats : OpenApiVisitorBase
     public int LinkCount { get; set; } = 0;
     public int CallbackCount { get; set; } = 0;
 
-    public override void Visit(OpenApiParameter parameter)
+    public override void Visit(IOpenApiParameter parameter)
     {
         ParameterCount++;
     }
 
-    public override void Visit(OpenApiSchema schema)
+    public override void Visit(IOpenApiSchema schema)
     {
         SchemaCount++;
     }
 
 
-    public override void Visit(IDictionary<string, OpenApiHeader> headers)
+    public override void Visit(IDictionary<string, IOpenApiHeader> headers)
     {
         HeaderCount++;
     }
 
 
-    public override void Visit(OpenApiPathItem pathItem)
+    public override void Visit(IOpenApiPathItem pathItem)
     {
         PathItemCount++;
     }
 
 
-    public override void Visit(OpenApiRequestBody requestBody)
+    public override void Visit(IOpenApiRequestBody requestBody)
     {
         RequestBodyCount++;
     }
@@ -56,12 +55,12 @@ public class OpenApiStats : OpenApiVisitorBase
     }
 
 
-    public override void Visit(OpenApiLink link)
+    public override void Visit(IOpenApiLink link)
     {
         LinkCount++;
     }
 
-    public override void Visit(OpenApiCallback callback)
+    public override void Visit(IOpenApiCallback callback)
     {
         CallbackCount++;
     }

--- a/src/HttpGenerator/Validation/OpenApiValidationResult.cs
+++ b/src/HttpGenerator/Validation/OpenApiValidationResult.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.OpenApi.Readers;
+﻿using Microsoft.OpenApi.Reader;
 
 namespace HttpGenerator.Validation;
 

--- a/src/HttpGenerator/Validation/OpenApiValidator.cs
+++ b/src/HttpGenerator/Validation/OpenApiValidator.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net;
 using System.Security;
-using Microsoft.OpenApi.Readers;
-using Microsoft.OpenApi.Services;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Reader;
 
 namespace HttpGenerator.Validation;
 
@@ -13,10 +13,10 @@ public static class OpenApiValidator
 
         var statsVisitor = new OpenApiStats();
         var walker = new OpenApiWalker(statsVisitor);
-        walker.Walk(result.OpenApiDocument);
+        walker.Walk(result.Document);
 
         return new(
-            result.OpenApiDiagnostic,
+            result.Diagnostic ?? new OpenApiDiagnostic(),
             statsVisitor);
     }
 
@@ -78,9 +78,21 @@ public static class OpenApiValidator
         {
             BaseUrl = baseUrl
         };
+        openApiReaderSettings.AddYamlReader();
 
         await using var stream = await GetStream(openApiFile, CancellationToken.None);
-        var reader = new OpenApiStreamReader(openApiReaderSettings);
-        return await reader.ReadAsync(stream, CancellationToken.None);
+        var format = GetFormat(openApiFile);
+        return await OpenApiDocument.LoadAsync(stream, format, openApiReaderSettings, CancellationToken.None);
+    }
+
+    private static string GetFormat(string openApiFile)
+    {
+        if (openApiFile.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) ||
+            openApiFile.EndsWith(".yml", StringComparison.OrdinalIgnoreCase))
+        {
+            return "yaml";
+        }
+
+        return "json";
     }
 }


### PR DESCRIPTION
## Summary
- upgrade Microsoft.OpenApi to 3.4.0 and switch to Microsoft.OpenApi.YamlReader
- migrate reader pipeline to OpenApiDocument.LoadAsync with format detection + YAML reader settings
- update reader/validator/stats paths for new OpenApi interfaces and namespaces
- remove unused Microsoft.OpenApi.OData dependency

## Testing
- dotnet restore HttpGenerator.sln
- dotnet build HttpGenerator.sln --configuration Release
- dotnet test HttpGenerator.sln --configuration Release --no-build --filter "FullyQualifiedName~OpenApiDocumentFactoryTests&FullyQualifiedName~Create_From_File_Returns_NotNull" --logger "console;verbosity=minimal"
- dotnet test HttpGenerator.sln --configuration Release --no-build --filter "FullyQualifiedName~OpenApiValidatorTests&FullyQualifiedName~Should_Return_True_For_Local_Files" --logger "console;verbosity=minimal"
- dotnet test HttpGenerator.sln --configuration Release --no-build --filter FullyQualifiedName~OpenApiDocumentFactoryTests (running; remote endpoints slow in this env)
- dotnet test HttpGenerator.sln --configuration Release --no-build --filter FullyQualifiedName~OpenApiValidatorTests (pending after above)
- dotnet run --project src/HttpGenerator/HttpGenerator.csproj -- test/OpenAPI/v3.0/petstore.json --output C:\Users\chris\.copilot\session-state\ef03721e-dec6-4956-aec1-fa2cfe171296\files\cli-output --no-logging

Fixes #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for YAML-formatted OpenAPI specifications alongside existing JSON support.

* **Bug Fixes**
  * Enhanced validation robustness with improved error handling and null-safety in specification parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->