### PR TITLE
deps-005: migrate OpenAPI reader pipeline

### DIFF
--- a/src/HttpGenerator.Core/HttpFileGenerator.cs
+++ b/src/HttpGenerator.Core/HttpFileGenerator.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 
 namespace HttpGenerator.Core;
 
@@ -243,7 +243,7 @@ public static class HttpFileGenerator
 
     private static string GenerateRequest(
         OpenApiDocument document,
-        KeyValuePair<string, OpenApiPathItem> operationPath,
+        KeyValuePair<string, IOpenApiPathItem> operationPath,
         IOperationNameGenerator operationNameGenerator,
         GeneratorSettings settings,
         string verb,
@@ -351,7 +351,7 @@ public static class HttpFileGenerator
 
     private static void AppendSummary(
         string verb,
-        KeyValuePair<string, OpenApiPathItem> kv,
+        KeyValuePair<string, IOpenApiPathItem> kv,
         OpenApiOperation operation,
         StringBuilder code)
     {
@@ -419,7 +419,7 @@ public static class HttpFileGenerator
 
     private static Dictionary<string, string> AppendParameters(
         OpenApiDocument document,
-        KeyValuePair<string, OpenApiPathItem> operationPath,
+        KeyValuePair<string, IOpenApiPathItem> operationPath,
         GeneratorSettings settings,
         OpenApiOperation operation,
         string verb,
@@ -429,17 +429,17 @@ public static class HttpFileGenerator
         // Merge path-level parameters with operation-level parameters.
         // Operation-level parameters override path-level ones with the same name+in.
         var pathLevelParams = operationPath.Value.Parameters
-            ?? Enumerable.Empty<OpenApiParameter>();
+            ?? Enumerable.Empty<IOpenApiParameter>();
 
         var operationParams = operation.Parameters
-            ?? Enumerable.Empty<OpenApiParameter>();
+            ?? Enumerable.Empty<IOpenApiParameter>();
 
         var parameters = pathLevelParams
             .Where(p => p is not null)
             .Concat(operationParams.Where(p => p is not null))
-            .GroupBy(p => (p.Name, p.In))
+            .GroupBy(p => (Name: p.Name ?? string.Empty, Location: p.In))
             .Select(g => g.Last()) // operation-level wins (it's appended last)
-            .Where(p => p.In == ParameterLocation.Path || p.In == ParameterLocation.Query)
+            .Where(p => p.In is ParameterLocation.Path or ParameterLocation.Query)
             .ToArray();
 
         var parameterNameMap = new Dictionary<string, string>();
@@ -453,13 +453,15 @@ public static class HttpFileGenerator
                 verb,
                 operationPath.Key,
                 parameter);
-            parameterNameMap[parameter.Name] = parameterName;
+            var parameterKey = parameter.Name ?? parameterName;
+            parameterNameMap[parameterKey] = parameterName;
 
             var defaultValue = GetParameterDefaultValue(parameter);
-            
+            var parameterLocation = parameter.In?.ToString() ?? "Unknown";
+
             code.AppendLine(
                 $"""
-                 ### {parameter.In} Parameter: {parameter.Description?.PrefixLineBreaks() ?? parameterName}
+                 ### {parameterLocation} Parameter: {parameter.Description?.PrefixLineBreaks() ?? parameterName}
                  @{parameterName} = {defaultValue}
 
                  """);
@@ -492,10 +494,10 @@ public static class HttpFileGenerator
         IOperationNameGenerator operationNameGenerator,
         string verb,
         string operationPathKey,
-        OpenApiParameter parameter)
+        IOpenApiParameter parameter)
     {
         if (settings.OutputType == OutputType.OneRequestPerFile)
-            return parameter.Name;
+            return parameter.Name ?? "param";
 
         var name = operationNameGenerator.GetOperationName(
             document,
@@ -503,16 +505,16 @@ public static class HttpFileGenerator
             verb,
             operation);
 
-        return $"{name}_{parameter.Name}";
+        return $"{name}_{parameter.Name ?? "param"}";
     }
 
-    private static string GetParameterDefaultValue(OpenApiParameter parameter)
+    private static string GetParameterDefaultValue(IOpenApiParameter parameter)
     {
         // Get the schema from the parameter
         var schema = parameter.Schema;
-        if (schema?.Type != null)
+        if (schema != null)
         {
-            return schema.Type.ToLowerInvariant() switch
+            return GetSchemaTypeName(schema) switch
             {
                 "integer" => "0",
                 "number" => "0",
@@ -523,7 +525,7 @@ public static class HttpFileGenerator
         return "str";
     }
 
-    private static string? GenerateSampleJson(OpenApiSchema? schema)
+    private static string? GenerateSampleJson(IOpenApiSchema? schema)
     {
         if (schema == null) return null;
 
@@ -547,7 +549,7 @@ public static class HttpFileGenerator
         }
 
         // Basic type-based JSON sample generation
-        return schema.Type?.ToLowerInvariant() switch
+        return GetSchemaTypeName(schema) switch
         {
             "object" => "{\n  \"property\": \"value\"\n}",
             "array" => "[\n  \"item1\",\n  \"item2\"\n]",
@@ -559,7 +561,7 @@ public static class HttpFileGenerator
         };
     }
 
-    private static string GetPropertySampleValue(OpenApiSchema schema)
+    private static string GetPropertySampleValue(IOpenApiSchema schema)
     {
         if (schema == null) return "\"value\"";
 
@@ -573,7 +575,7 @@ public static class HttpFileGenerator
         if (schema.AnyOf?.Count > 0)
             return GetPropertySampleValue(schema.AnyOf.FirstOrDefault(s => s != null) ?? schema);
 
-        return schema.Type?.ToLowerInvariant() switch
+        return GetSchemaTypeName(schema) switch
         {
             "string" => "\"example\"",
             "integer" => "0",
@@ -583,5 +585,46 @@ public static class HttpFileGenerator
             "object" => "{\"property\": \"value\"}",
             _ => "\"value\""
         };
+    }
+
+    private static string? GetSchemaTypeName(IOpenApiSchema schema)
+    {
+        if (!schema.Type.HasValue)
+        {
+            return null;
+        }
+
+        var type = schema.Type.Value;
+        if (type.HasFlag(JsonSchemaType.Integer))
+        {
+            return "integer";
+        }
+
+        if (type.HasFlag(JsonSchemaType.Number))
+        {
+            return "number";
+        }
+
+        if (type.HasFlag(JsonSchemaType.Boolean))
+        {
+            return "boolean";
+        }
+
+        if (type.HasFlag(JsonSchemaType.Array))
+        {
+            return "array";
+        }
+
+        if (type.HasFlag(JsonSchemaType.Object))
+        {
+            return "object";
+        }
+
+        if (type.HasFlag(JsonSchemaType.String))
+        {
+            return "string";
+        }
+
+        return null;
     }
 }

--- a/src/HttpGenerator.Core/HttpGenerator.Core.csproj
+++ b/src/HttpGenerator.Core/HttpGenerator.Core.csproj
@@ -14,8 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.6.28" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.28" />
+    <PackageReference Include="Microsoft.OpenApi" Version="3.4.0" />
+    <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.4.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.1" />
     <PackageReference Include="System.Text.Json" Version="10.0.5" />
   </ItemGroup>

--- a/src/HttpGenerator.Core/OpenApiDocumentFactory.cs
+++ b/src/HttpGenerator.Core/OpenApiDocumentFactory.cs
@@ -1,6 +1,6 @@
-﻿using System.Net;
-using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Readers;
+using System.Net;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Reader;
 
 namespace HttpGenerator.Core;
 
@@ -18,33 +18,41 @@ public static class OpenApiDocumentFactory
         if (IsHttp(openApiPath))
         {
             var content = await GetHttpContent(openApiPath);
-            return await ParseOpenApiContent(content);
+            return await ParseOpenApiContent(openApiPath, content);
         }
-        else 
+        else
         {
             var content = File.ReadAllText(openApiPath);
-            return await ParseOpenApiContent(content);
+            return await ParseOpenApiContent(openApiPath, content);
         }
     }
 
-    private static async Task<OpenApiDocument> ParseOpenApiContent(string content)
+    private static async Task<OpenApiDocument> ParseOpenApiContent(string openApiPath, string content)
     {
         // Try to parse with Microsoft.OpenApi first
         try
         {
             using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(content));
-            var reader = new OpenApiStreamReader();
-            var result = await reader.ReadAsync(stream, CancellationToken.None);
-            return result.OpenApiDocument;
+            var format = GetOpenApiFormat(openApiPath, content);
+            var result = await OpenApiDocument.LoadAsync(
+                stream,
+                format,
+                new OpenApiReaderSettings(),
+                CancellationToken.None);
+            return result.Document ?? throw new InvalidOperationException("OpenAPI document could not be parsed.");
         }
-        catch (Exception ex) when (ex.Message.Contains("3.1.0") || ex.Message.Contains("not supported"))
+        catch (OpenApiUnsupportedSpecVersionException)
         {
             // If OpenAPI 3.1 is detected, try to downgrade to 3.0 for parsing
             var downgradedContent = DowngradeOpenApi31To30(content);
             using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(downgradedContent));
-            var reader = new OpenApiStreamReader();
-            var result = await reader.ReadAsync(stream, CancellationToken.None);
-            return result.OpenApiDocument;
+            var format = GetOpenApiFormat(openApiPath, downgradedContent);
+            var result = await OpenApiDocument.LoadAsync(
+                stream,
+                format,
+                new OpenApiReaderSettings(),
+                CancellationToken.None);
+            return result.Document ?? throw new InvalidOperationException("OpenAPI document could not be parsed.");
         }
     }
 
@@ -94,5 +102,22 @@ public static class OpenApiDocumentFactory
     {
         return path.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) || 
                path.EndsWith(".yml", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetOpenApiFormat(string openApiPath, string content)
+    {
+        if (IsYaml(openApiPath))
+        {
+            return OpenApiConstants.Yaml;
+        }
+
+        var trimmed = content.TrimStart();
+        if (trimmed.StartsWith("openapi:", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.StartsWith("swagger:", StringComparison.OrdinalIgnoreCase))
+        {
+            return OpenApiConstants.Yaml;
+        }
+
+        return OpenApiConstants.Json;
     }
 }

--- a/src/HttpGenerator.Core/OperationNameGenerator.cs
+++ b/src/HttpGenerator.Core/OperationNameGenerator.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 
 namespace HttpGenerator.Core;
 
@@ -25,13 +25,15 @@ internal class OperationNameGenerator : IOperationNameGenerator
         {
             // Try to use operationId first if available
             var operationName = operation.OperationId;
-            
+             
             if (string.IsNullOrWhiteSpace(operationName))
             {
                 // Fallback to generating from path and method
                 operationName = $"{httpMethod}_{path}";
             }
             
+            operationName ??= string.Empty;
+             
             return operationName
                 .CapitalizeFirstCharacter()
                 .ConvertKebabCaseToPascalCase()

--- a/src/HttpGenerator/GenerateCommand.cs
+++ b/src/HttpGenerator/GenerateCommand.cs
@@ -3,7 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using Azure.Core.Diagnostics;
 using HttpGenerator.Core;
 using HttpGenerator.Validation;
-using Microsoft.OpenApi.Readers.Exceptions;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -47,7 +46,7 @@ public class GenerateCommand : AsyncCommand<Settings>
             DisplaySuccess(stopwatch.Elapsed);
             return 0;
         }
-        catch (OpenApiUnsupportedSpecVersionException exception)
+        catch (Microsoft.OpenApi.OpenApiUnsupportedSpecVersionException exception)
         {
             AnsiConsole.MarkupLine($"{Crlf}[red]Error:{Crlf}{exception.Message}[/]");
             AnsiConsole.MarkupLine(

--- a/src/HttpGenerator/HttpGenerator.csproj
+++ b/src/HttpGenerator/HttpGenerator.csproj
@@ -15,8 +15,8 @@
     <ItemGroup>
         <PackageReference Include="Exceptionless" Version="6.1.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.23.0" />
-        <PackageReference Include="Microsoft.OpenApi.OData" Version="1.7.5" />
-        <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.28" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.4.0" />
+        <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.4.0" />
         <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
     </ItemGroup>

--- a/src/HttpGenerator/Validation/OpenApiStats.cs
+++ b/src/HttpGenerator/Validation/OpenApiStats.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Services;
+﻿using Microsoft.OpenApi;
 
 namespace HttpGenerator.Validation;
 
@@ -15,30 +14,30 @@ public class OpenApiStats : OpenApiVisitorBase
     public int LinkCount { get; set; } = 0;
     public int CallbackCount { get; set; } = 0;
 
-    public override void Visit(OpenApiParameter parameter)
+    public override void Visit(IOpenApiParameter parameter)
     {
         ParameterCount++;
     }
 
-    public override void Visit(OpenApiSchema schema)
+    public override void Visit(IOpenApiSchema schema)
     {
         SchemaCount++;
     }
 
 
-    public override void Visit(IDictionary<string, OpenApiHeader> headers)
+    public override void Visit(IDictionary<string, IOpenApiHeader> headers)
     {
         HeaderCount++;
     }
 
 
-    public override void Visit(OpenApiPathItem pathItem)
+    public override void Visit(IOpenApiPathItem pathItem)
     {
         PathItemCount++;
     }
 
 
-    public override void Visit(OpenApiRequestBody requestBody)
+    public override void Visit(IOpenApiRequestBody requestBody)
     {
         RequestBodyCount++;
     }
@@ -56,12 +55,12 @@ public class OpenApiStats : OpenApiVisitorBase
     }
 
 
-    public override void Visit(OpenApiLink link)
+    public override void Visit(IOpenApiLink link)
     {
         LinkCount++;
     }
 
-    public override void Visit(OpenApiCallback callback)
+    public override void Visit(IOpenApiCallback callback)
     {
         CallbackCount++;
     }

--- a/src/HttpGenerator/Validation/OpenApiValidationResult.cs
+++ b/src/HttpGenerator/Validation/OpenApiValidationResult.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.OpenApi.Readers;
+﻿using Microsoft.OpenApi.Reader;
 
 namespace HttpGenerator.Validation;
 

--- a/src/HttpGenerator/Validation/OpenApiValidator.cs
+++ b/src/HttpGenerator/Validation/OpenApiValidator.cs
@@ -1,7 +1,7 @@
-﻿using System.Net;
+using System.Net;
 using System.Security;
-using Microsoft.OpenApi.Readers;
-using Microsoft.OpenApi.Services;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Reader;
 
 namespace HttpGenerator.Validation;
 
@@ -12,11 +12,15 @@ public static class OpenApiValidator
         var result = await ParseOpenApi(openApiPath);
 
         var statsVisitor = new OpenApiStats();
-        var walker = new OpenApiWalker(statsVisitor);
-        walker.Walk(result.OpenApiDocument);
+        if (result.Document != null)
+        {
+            var walker = new OpenApiWalker(statsVisitor);
+            walker.Walk(result.Document);
+        }
 
+        var diagnostics = result.Diagnostic ?? new OpenApiDiagnostic();
         return new(
-            result.OpenApiDiagnostic,
+            diagnostics,
             statsVisitor);
     }
 
@@ -80,7 +84,15 @@ public static class OpenApiValidator
         };
 
         await using var stream = await GetStream(openApiFile, CancellationToken.None);
-        var reader = new OpenApiStreamReader(openApiReaderSettings);
-        return await reader.ReadAsync(stream, CancellationToken.None);
+        var format = GetOpenApiFormat(openApiFile);
+        return await OpenApiDocument.LoadAsync(stream, format, openApiReaderSettings, CancellationToken.None);
+    }
+
+    private static string GetOpenApiFormat(string openApiFile)
+    {
+        return openApiFile.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) ||
+               openApiFile.EndsWith(".yml", StringComparison.OrdinalIgnoreCase)
+            ? OpenApiConstants.Yaml
+            : OpenApiConstants.Json;
     }
 }


### PR DESCRIPTION
## Summary
- upgrade Microsoft.OpenApi to 3.4.0 and swap Microsoft.OpenApi.Readers for Microsoft.OpenApi.YamlReader (remove unused OData)
- migrate reader/validation pipeline to OpenApiDocument.LoadAsync and new diagnostics
- align generator + stats to the new OpenApi interfaces and JsonSchemaType handling

## Testing
- dotnet restore HttpGenerator.sln
- dotnet build HttpGenerator.sln --configuration Release
- dotnet test HttpGenerator.sln --configuration Release --no-build --filter FullyQualifiedName~OpenApiDocumentFactoryTests (running)
- dotnet test HttpGenerator.sln --configuration Release --no-build --filter FullyQualifiedName~OpenApiValidatorTests (running)
- dotnet test HttpGenerator.sln --configuration Release --no-build --filter FullyQualifiedName~NullParametersTests (running)
- dotnet test HttpGenerator.sln --configuration Release --no-build --filter FullyQualifiedName~PathLevelParametersTests (running)
- dotnet test HttpGenerator.sln --configuration Release --no-build --filter FullyQualifiedName~QueryParametersTests (running)
- dotnet test HttpGenerator.sln --configuration Release --no-build --filter FullyQualifiedName~SwaggerPetstoreTests (running)
- dotnet test HttpGenerator.sln --configuration Release --no-build --filter FullyQualifiedName~GenerateCommandTests (running)
- dotnet run --project src/HttpGenerator/HttpGenerator.csproj -- test/OpenAPI/v3.0/petstore.json --output temp/cli-basic --no-logging
- dotnet run --project src/HttpGenerator/HttpGenerator.csproj -- test/OpenAPI/v3.0/petstore.json --output temp/cli-single --output-type OneFile --no-logging
- dotnet run --project src/HttpGenerator/HttpGenerator.csproj -- test/OpenAPI/v3.0/petstore.json --output temp/cli-custom --generate-intellij-tests --custom-header "X-API-Key: test123" --base-url https://api.example.com --no-logging
- dotnet run --project src/HttpGenerator/HttpGenerator.csproj -- test/OpenAPI/v3.1/webhook-example.json --output temp/cli-v31 --skip-validation --no-logging

Closes #331