### PR TITLE
Upgrade Spectre.Console.Cli from 0.53.1 to 0.55.0

### DIFF
--- a/src/HttpGenerator.Tests/GenerateCommandTests.cs
+++ b/src/HttpGenerator.Tests/GenerateCommandTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using HttpGenerator.Tests.Resources;
 using Spectre.Console.Cli;
+using System.Reflection;
 using Inline = Atc.Test.InlineAutoNSubstituteDataAttribute;
 
 namespace HttpGenerator.Tests;
@@ -44,7 +45,7 @@ public class GenerateCommandTests
         settings.OpenApiPath = await TestFile.CreateSwaggerFile(json, filename);
         settings.NoLogging = true;
 
-        (await sut.ExecuteAsync(context, settings, TestContext.Current.CancellationToken))
+        (await InvokeExecuteAsync(sut, context, settings, TestContext.Current.CancellationToken))
             .Should()
             .Be(0);
     }
@@ -69,7 +70,7 @@ public class GenerateCommandTests
         settings.NoLogging = true;
         settings.SkipValidation = true;
 
-        (await sut.ExecuteAsync(context, settings, TestContext.Current.CancellationToken))
+        (await InvokeExecuteAsync(sut, context, settings, TestContext.Current.CancellationToken))
             .Should()
             .Be(0);
     }
@@ -94,7 +95,7 @@ public class GenerateCommandTests
         settings.NoLogging = true;
         settings.SkipValidation = false;
 
-        (await sut.ExecuteAsync(context, settings, TestContext.Current.CancellationToken))
+        (await InvokeExecuteAsync(sut, context, settings, TestContext.Current.CancellationToken))
             .Should()
             .Be(0);
     }
@@ -117,7 +118,7 @@ public class GenerateCommandTests
         settings.OpenApiPath = url;
         settings.NoLogging = true;
 
-        (await sut.ExecuteAsync(context, settings, TestContext.Current.CancellationToken))
+        (await InvokeExecuteAsync(sut, context, settings, TestContext.Current.CancellationToken))
             .Should()
             .Be(0);
     }
@@ -133,8 +134,19 @@ public class GenerateCommandTests
         settings.OpenApiPath = url;
         settings.NoLogging = true;
 
-        (await sut.ExecuteAsync(context, settings, TestContext.Current.CancellationToken))
+        (await InvokeExecuteAsync(sut, context, settings, TestContext.Current.CancellationToken))
             .Should()
             .NotBe(0);
+    }
+    private static async Task<int> InvokeExecuteAsync(
+        GenerateCommand command,
+        CommandContext context,
+        Settings settings,
+        CancellationToken cancellationToken)
+    {
+        var method = typeof(GenerateCommand).GetMethod(
+            "ExecuteAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return await (Task<int>)method.Invoke(command, new object[] { context, settings, cancellationToken })!;
     }
 }

--- a/src/HttpGenerator/GenerateCommand.cs
+++ b/src/HttpGenerator/GenerateCommand.cs
@@ -14,7 +14,7 @@ public class GenerateCommand : AsyncCommand<Settings>
 {
     private static readonly string Crlf = Environment.NewLine;
 
-    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken = default)
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken = default)
     {
         Analytics.Configure(settings);
 

--- a/src/HttpGenerator/HttpGenerator.csproj
+++ b/src/HttpGenerator/HttpGenerator.csproj
@@ -15,7 +15,7 @@
     <ItemGroup>
         <PackageReference Include="Exceptionless" Version="6.1.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.23.0" />
-        <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
+        <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary

Upgrades `Spectre.Console.Cli` from `0.53.x` to `0.55.0`.

## Breaking Changes Addressed

In `0.55.0`, `AsyncCommand<T>.ExecuteAsync()` changed from `public` to `protected`. This caused `CS0507` compiler errors.

### Changes
- **`.csproj`**: bumped `Spectre.Console.Cli` version to `0.55.0`
- **`GenerateCommand.cs`**: changed `public override` → `protected override` on `ExecuteAsync`
- **`GenerateCommandTests.cs`**: updated tests to call `ExecuteAsync` via reflection (required since the method is now `protected`)