### PR TITLE
Publish Rust app to crates.io

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ Always reference these instructions first and fall back to deeper code search on
 - **Never cancel builds or smoke tests.**
 - Rust validation:
   - `cargo test`
-  - `cargo run -q -p httpgenerator-cli -- test\OpenAPI\v3.0\petstore.json --output <dir> --no-logging`
+  - `cargo run -q -p httpgenerator -- test\OpenAPI\v3.0\petstore.json --output <dir> --no-logging`
 - .NET oracle validation:
   - `dotnet restore src/dotnet/HttpGenerator.slnx`
   - `dotnet build src/dotnet/HttpGenerator.slnx --configuration Release`

--- a/.github/scripts/check-crates-io-version.py
+++ b/.github/scripts/check-crates-io-version.py
@@ -14,7 +14,9 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Wait for, or assert the absence of, a crate version on crates.io."
     )
-    parser.add_argument("--crate", required=True, help="Crate name to query on crates.io.")
+    parser.add_argument(
+        "--crate", required=True, help="Crate name to query on crates.io."
+    )
     parser.add_argument("--version", required=True, help="Version to look for.")
     parser.add_argument(
         "--state",
@@ -54,11 +56,34 @@ def main() -> int:
     args = parse_args()
 
     for attempt in range(1, args.retries + 1):
-        versions = fetch_versions(args.crate)
+        try:
+            versions = fetch_versions(args.crate)
+        except (urllib.error.URLError, urllib.error.HTTPError) as e:
+            if isinstance(e, urllib.error.HTTPError) and e.code != 404:
+                print(
+                    f"Warning: HTTP Error {e.code} encountered for {args.crate}. Retrying..."
+                )
+            else:
+                # For URLError or non-transient HTTP errors (like 4xx other than 404), re-raise/break the loop if this was the last attempt
+                if attempt == args.retries:
+                    raise e
+                print(
+                    f"Warning: Network error encountered for {args.crate}: {e}. Retrying..."
+                )
+
+            # If we are here, it means an exception occurred and we need to retry (unless this is the last attempt)
+            if attempt < args.retries:
+                time.sleep(args.delay_seconds)
+                continue  # Continue loop on retry
+
+            raise e  # Re-raise if it was the final attempt
+
         is_present = args.version in versions
 
         if args.state == "present" and is_present:
-            print(f"{args.crate} {args.version} is visible on crates.io after {attempt} check(s).")
+            print(
+                f"{args.crate} {args.version} is visible on crates.io after {attempt} check(s)."
+            )
             return 0
 
         if args.state == "absent" and not is_present:

--- a/.github/scripts/check-crates-io-version.py
+++ b/.github/scripts/check-crates-io-version.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Wait for, or assert the absence of, a crate version on crates.io."
+    )
+    parser.add_argument("--crate", required=True, help="Crate name to query on crates.io.")
+    parser.add_argument("--version", required=True, help="Version to look for.")
+    parser.add_argument(
+        "--state",
+        choices=("present", "absent"),
+        required=True,
+        help="Expected visibility state for the requested version.",
+    )
+    parser.add_argument(
+        "--retries",
+        type=int,
+        default=1,
+        help="Number of checks to perform before failing.",
+    )
+    parser.add_argument(
+        "--delay-seconds",
+        type=int,
+        default=0,
+        help="Delay between retries.",
+    )
+    return parser.parse_args()
+
+
+def fetch_versions(crate_name: str) -> set[str]:
+    url = f"https://crates.io/api/v1/crates/{crate_name}"
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return set()
+        raise
+
+    return {item["num"] for item in payload.get("versions", [])}
+
+
+def main() -> int:
+    args = parse_args()
+
+    for attempt in range(1, args.retries + 1):
+        versions = fetch_versions(args.crate)
+        is_present = args.version in versions
+
+        if args.state == "present" and is_present:
+            print(f"{args.crate} {args.version} is visible on crates.io after {attempt} check(s).")
+            return 0
+
+        if args.state == "absent" and not is_present:
+            print(f"{args.crate} {args.version} is not present on crates.io.")
+            return 0
+
+        if attempt < args.retries and args.delay_seconds > 0:
+            print(
+                f"Waiting for {args.crate} {args.version} to become {args.state} "
+                f"(attempt {attempt}/{args.retries})."
+            )
+            time.sleep(args.delay_seconds)
+
+    expected = "visible on" if args.state == "present" else "absent from"
+    print(
+        f"::error::{args.crate} {args.version} was not {expected} crates.io after {args.retries} check(s).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/set-rust-workspace-version.py
+++ b/.github/scripts/set-rust-workspace-version.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+
+PLACEHOLDER = 'version = "0.1.0"'
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Update every shared Rust workspace version placeholder in Cargo.toml."
+    )
+    parser.add_argument("--version", required=True, help="Semver to inject into the workspace manifest.")
+    parser.add_argument(
+        "--manifest",
+        default="Cargo.toml",
+        help="Path to the workspace Cargo.toml file (default: Cargo.toml).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    manifest_path = Path(args.manifest)
+    contents = manifest_path.read_text(encoding="utf-8")
+    replacements = contents.count(PLACEHOLDER)
+    if replacements == 0:
+        print(
+            f"No '{PLACEHOLDER}' anchors found in {manifest_path}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    manifest_path.write_text(
+        contents.replace(PLACEHOLDER, f'version = "{args.version}"'),
+        encoding="utf-8",
+    )
+    print(f"Updated {replacements} version anchor(s) in {manifest_path}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
       - "*"
     paths:
       - ".github/workflows/build.yml"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/release-template.yml"
+      - ".github/scripts/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - "src/rust/**"
@@ -18,6 +21,9 @@ on:
       - "*"
     paths:
       - ".github/workflows/build.yml"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/release-template.yml"
+      - ".github/scripts/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - "src/rust/**"
@@ -72,6 +78,27 @@ jobs:
       - name: Compile extension
         working-directory: src/vscode
         run: npm run compile
+
+  publish-readiness:
+    name: crates.io publish readiness
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: 0.0.0-ci.${{ github.run_number }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Inject workspace release version
+        run: python .github/scripts/set-rust-workspace-version.py --version "$RELEASE_VERSION"
+
+      - name: Dry run: publish core
+        run: cargo publish --locked --dry-run --allow-dirty -p httpgenerator-core
+
+      - name: Build downstream crates with injected version
+        run: cargo check --locked -p httpgenerator-openapi -p httpgenerator
 
   vsix:
     name: VSIX solution

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         run: cargo publish --dry-run --allow-dirty -p httpgenerator-core
 
       - name: Build downstream crates with injected version
-        run: cargo check --locked -p httpgenerator-openapi -p httpgenerator
+        run: cargo check -p httpgenerator-openapi -p httpgenerator
 
   vsix:
     name: VSIX solution

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,8 +94,8 @@ jobs:
       - name: Inject workspace release version
         run: python .github/scripts/set-rust-workspace-version.py --version "$RELEASE_VERSION"
 
-      - name: Dry run: publish core
-        run: cargo publish --locked --dry-run --allow-dirty -p httpgenerator-core
+      - name: "Dry run: publish core"
+        run: cargo publish --dry-run --allow-dirty -p httpgenerator-core
 
       - name: Build downstream crates with injected version
         run: cargo check --locked -p httpgenerator-openapi -p httpgenerator

--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -49,7 +49,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build Rust CLI
-        run: cargo build --locked --release -p httpgenerator
+        run: cargo build --release -p httpgenerator
 
       - name: Stage artifact
         run: |
@@ -78,7 +78,7 @@ jobs:
         run: python .github/scripts/set-rust-workspace-version.py --version "$RELEASE_VERSION"
 
       - name: Build Rust CLI
-        run: cargo build --locked --release -p httpgenerator
+        run: cargo build --release -p httpgenerator
 
       - name: Stage artifact
         run: |
@@ -108,7 +108,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build Rust CLI
-        run: cargo build --locked --release -p httpgenerator
+        run: cargo build --release -p httpgenerator
 
       - name: Stage artifact
         run: |
@@ -146,7 +146,7 @@ jobs:
           node -e "const fs=require('fs'); const path='src/vscode/package.json'; const json=JSON.parse(fs.readFileSync(path, 'utf8')); json.version=process.env.RELEASE_VERSION; fs.writeFileSync(path, JSON.stringify(json, null, 2) + '\n');"
 
       - name: Build Rust CLI
-        run: cargo build --locked --release -p httpgenerator
+        run: cargo build --release -p httpgenerator
 
       - name: Bundle Rust CLI
         run: |
@@ -194,7 +194,7 @@ jobs:
           node -e "const fs=require('fs'); const path='src/vscode/package.json'; const json=JSON.parse(fs.readFileSync(path, 'utf8')); json.version=process.env.RELEASE_VERSION; fs.writeFileSync(path, JSON.stringify(json, null, 2) + '\n');"
 
       - name: Build Rust CLI
-        run: cargo build --locked --release -p httpgenerator
+        run: cargo build --release -p httpgenerator
 
       - name: Bundle Rust CLI
         run: |
@@ -246,7 +246,7 @@ jobs:
           node-version: "24"
 
       - name: Build Rust CLI
-        run: cargo build --locked --release -p httpgenerator
+        run: cargo build --release -p httpgenerator
 
       - name: Bundle Rust CLI
         run: |
@@ -291,7 +291,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build Rust CLI
-        run: cargo build --locked --release -p httpgenerator
+        run: cargo build --release -p httpgenerator
 
       - name: Bundle Rust CLI
         run: Copy-Item target\release\httpgenerator.exe src/dotnet/HttpGenerator.VSIX/httpgenerator.exe -Force
@@ -359,7 +359,7 @@ jobs:
           python .github/scripts/check-crates-io-version.py --crate httpgenerator --version "$RELEASE_VERSION" --state absent
 
       - name: Dry run - publish core
-        run: cargo publish --locked --dry-run --allow-dirty -p httpgenerator-core
+        run: cargo publish --dry-run --allow-dirty -p httpgenerator-core
 
   publish-crates:
     name: Publish crates.io packages
@@ -381,27 +381,27 @@ jobs:
         run: python .github/scripts/set-rust-workspace-version.py --version "$RELEASE_VERSION"
 
       - name: Publish httpgenerator-core
-        run: cargo publish --locked --allow-dirty -p httpgenerator-core
+        run: cargo publish --allow-dirty -p httpgenerator-core
 
       - name: Wait for httpgenerator-core on crates.io
         shell: bash
         run: python .github/scripts/check-crates-io-version.py --crate httpgenerator-core --version "$RELEASE_VERSION" --state present --retries 30 --delay-seconds 10
 
       - name: Dry run - publish httpgenerator-openapi
-        run: cargo publish --locked --dry-run --allow-dirty -p httpgenerator-openapi
+        run: cargo publish --dry-run --allow-dirty -p httpgenerator-openapi
 
       - name: Publish httpgenerator-openapi
-        run: cargo publish --locked --allow-dirty -p httpgenerator-openapi
+        run: cargo publish --allow-dirty -p httpgenerator-openapi
 
       - name: Wait for httpgenerator-openapi on crates.io
         shell: bash
         run: python .github/scripts/check-crates-io-version.py --crate httpgenerator-openapi --version "$RELEASE_VERSION" --state present --retries 30 --delay-seconds 10
 
       - name: Dry run - publish httpgenerator
-        run: cargo publish --locked --dry-run --allow-dirty -p httpgenerator
+        run: cargo publish --dry-run --allow-dirty -p httpgenerator
 
       - name: Publish httpgenerator
-        run: cargo publish --locked --allow-dirty -p httpgenerator
+        run: cargo publish --allow-dirty -p httpgenerator
 
   create-tag:
     name: Create tag

--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -6,6 +6,13 @@ on:
       version:
         required: true
         type: string
+      publish-crates:
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      CARGO_REGISTRY_TOKEN:
+        required: false
 
 jobs:
   validate-version:
@@ -36,13 +43,13 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Update Rust version
-        run: sed -i "s/^version = \"0\.1\.0\"$/version = \"$RELEASE_VERSION\"/" Cargo.toml
+        run: python .github/scripts/set-rust-workspace-version.py --version "$RELEASE_VERSION"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build Rust CLI
-        run: cargo build --locked --release -p httpgenerator-cli
+        run: cargo build --locked --release -p httpgenerator
 
       - name: Stage artifact
         run: |
@@ -68,10 +75,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Update Rust version
-        run: sed -i '' "s/^version = \"0\.1\.0\"$/version = \"$RELEASE_VERSION\"/" Cargo.toml
+        run: python .github/scripts/set-rust-workspace-version.py --version "$RELEASE_VERSION"
 
       - name: Build Rust CLI
-        run: cargo build --locked --release -p httpgenerator-cli
+        run: cargo build --locked --release -p httpgenerator
 
       - name: Stage artifact
         run: |
@@ -94,14 +101,14 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Update Rust version
-        run: ((Get-Content -Path Cargo.toml -Raw) -Replace 'version = "0\.1\.0"', ('version = "' + $env:RELEASE_VERSION + '"')) | Set-Content -Path Cargo.toml
+        run: python .github\scripts\set-rust-workspace-version.py --version $env:RELEASE_VERSION
         shell: pwsh
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build Rust CLI
-        run: cargo build --locked --release -p httpgenerator-cli
+        run: cargo build --locked --release -p httpgenerator
 
       - name: Stage artifact
         run: |
@@ -135,11 +142,11 @@ jobs:
 
       - name: Update versions
         run: |
-          sed -i "s/^version = \"0\.1\.0\"$/version = \"$RELEASE_VERSION\"/" Cargo.toml
+          python .github/scripts/set-rust-workspace-version.py --version "$RELEASE_VERSION"
           node -e "const fs=require('fs'); const path='src/vscode/package.json'; const json=JSON.parse(fs.readFileSync(path, 'utf8')); json.version=process.env.RELEASE_VERSION; fs.writeFileSync(path, JSON.stringify(json, null, 2) + '\n');"
 
       - name: Build Rust CLI
-        run: cargo build --locked --release -p httpgenerator-cli
+        run: cargo build --locked --release -p httpgenerator
 
       - name: Bundle Rust CLI
         run: |
@@ -183,11 +190,11 @@ jobs:
 
       - name: Update versions
         run: |
-          sed -i '' "s/^version = \"0\.1\.0\"$/version = \"$RELEASE_VERSION\"/" Cargo.toml
+          python .github/scripts/set-rust-workspace-version.py --version "$RELEASE_VERSION"
           node -e "const fs=require('fs'); const path='src/vscode/package.json'; const json=JSON.parse(fs.readFileSync(path, 'utf8')); json.version=process.env.RELEASE_VERSION; fs.writeFileSync(path, JSON.stringify(json, null, 2) + '\n');"
 
       - name: Build Rust CLI
-        run: cargo build --locked --release -p httpgenerator-cli
+        run: cargo build --locked --release -p httpgenerator
 
       - name: Bundle Rust CLI
         run: |
@@ -223,7 +230,7 @@ jobs:
 
       - name: Update versions
         run: |
-          ((Get-Content -Path Cargo.toml -Raw) -Replace 'version = "0\.1\.0"', ('version = "' + $env:RELEASE_VERSION + '"')) | Set-Content -Path Cargo.toml
+          python .github\scripts\set-rust-workspace-version.py --version $env:RELEASE_VERSION
           $path = 'src\vscode\package.json'
           $json = Get-Content $path -Raw | ConvertFrom-Json
           $json.version = $env:RELEASE_VERSION
@@ -239,7 +246,7 @@ jobs:
           node-version: "24"
 
       - name: Build Rust CLI
-        run: cargo build --locked --release -p httpgenerator-cli
+        run: cargo build --locked --release -p httpgenerator
 
       - name: Bundle Rust CLI
         run: |
@@ -276,7 +283,7 @@ jobs:
 
       - name: Update versions
         run: |
-          ((Get-Content -Path Cargo.toml -Raw) -Replace 'version = "0\.1\.0"', ('version = "' + $env:RELEASE_VERSION + '"')) | Set-Content -Path Cargo.toml
+          python .github\scripts\set-rust-workspace-version.py --version $env:RELEASE_VERSION
           ((Get-Content -Path src/dotnet/HttpGenerator.VSIX/source.extension.vsixmanifest -Raw) -Replace '1.0.0', $env:RELEASE_VERSION) | Set-Content -Path src/dotnet/HttpGenerator.VSIX/source.extension.vsixmanifest
         shell: pwsh
 
@@ -284,7 +291,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build Rust CLI
-        run: cargo build --locked --release -p httpgenerator-cli
+        run: cargo build --locked --release -p httpgenerator
 
       - name: Bundle Rust CLI
         run: Copy-Item target\release\httpgenerator.exe src/dotnet/HttpGenerator.VSIX/httpgenerator.exe -Force
@@ -311,8 +318,9 @@ jobs:
             *.vsix
             docs/Marketplace*.md
 
-  create-tag:
-    name: Create tag
+  validate-publish:
+    name: Validate crate publishing
+    if: ${{ inputs.publish-crates }}
     needs:
       - validate-version
       - cli-linux
@@ -325,6 +333,106 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_VERSION: ${{ needs.validate-version.outputs.release-version }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Ensure crates.io token is configured
+        shell: bash
+        run: |
+          if [[ -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
+            echo "::error::CARGO_REGISTRY_TOKEN secret is required when publish-crates is enabled."
+            exit 1
+          fi
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Update Rust version
+        run: python .github/scripts/set-rust-workspace-version.py --version "$RELEASE_VERSION"
+
+      - name: Fail if release version already exists on crates.io
+        shell: bash
+        run: |
+          python .github/scripts/check-crates-io-version.py --crate httpgenerator-core --version "$RELEASE_VERSION" --state absent
+          python .github/scripts/check-crates-io-version.py --crate httpgenerator-openapi --version "$RELEASE_VERSION" --state absent
+          python .github/scripts/check-crates-io-version.py --crate httpgenerator --version "$RELEASE_VERSION" --state absent
+
+      - name: Dry run: publish core
+        run: cargo publish --locked --dry-run --allow-dirty -p httpgenerator-core
+
+  publish-crates:
+    name: Publish crates.io packages
+    if: ${{ inputs.publish-crates }}
+    needs:
+      - validate-version
+      - validate-publish
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ needs.validate-version.outputs.release-version }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Update Rust version
+        run: python .github/scripts/set-rust-workspace-version.py --version "$RELEASE_VERSION"
+
+      - name: Publish httpgenerator-core
+        run: cargo publish --locked --allow-dirty -p httpgenerator-core
+
+      - name: Wait for httpgenerator-core on crates.io
+        shell: bash
+        run: python .github/scripts/check-crates-io-version.py --crate httpgenerator-core --version "$RELEASE_VERSION" --state present --retries 30 --delay-seconds 10
+
+      - name: Dry run: publish httpgenerator-openapi
+        run: cargo publish --locked --dry-run --allow-dirty -p httpgenerator-openapi
+
+      - name: Publish httpgenerator-openapi
+        run: cargo publish --locked --allow-dirty -p httpgenerator-openapi
+
+      - name: Wait for httpgenerator-openapi on crates.io
+        shell: bash
+        run: python .github/scripts/check-crates-io-version.py --crate httpgenerator-openapi --version "$RELEASE_VERSION" --state present --retries 30 --delay-seconds 10
+
+      - name: Dry run: publish httpgenerator
+        run: cargo publish --locked --dry-run --allow-dirty -p httpgenerator
+
+      - name: Publish httpgenerator
+        run: cargo publish --locked --allow-dirty -p httpgenerator
+
+  create-tag:
+    name: Create tag
+    needs:
+      - validate-version
+      - cli-linux
+      - cli-macos
+      - cli-windows
+      - vscode-linux
+      - vscode-macos
+      - vscode-windows
+      - vsix
+      - validate-publish
+      - publish-crates
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ needs.validate-version.outputs.release-version }}
+    if: >-
+      ${{
+        always() &&
+        needs.validate-version.result == 'success' &&
+        needs.cli-linux.result == 'success' &&
+        needs.cli-macos.result == 'success' &&
+        needs.cli-windows.result == 'success' &&
+        needs.vscode-linux.result == 'success' &&
+        needs.vscode-macos.result == 'success' &&
+        needs.vscode-windows.result == 'success' &&
+        needs.vsix.result == 'success' &&
+        (needs.validate-publish.result == 'success' || needs.validate-publish.result == 'skipped') &&
+        (needs.publish-crates.result == 'success' || needs.publish-crates.result == 'skipped')
+      }}
     steps:
       - name: Create tag
         uses: actions/github-script@v9

--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -358,7 +358,7 @@ jobs:
           python .github/scripts/check-crates-io-version.py --crate httpgenerator-openapi --version "$RELEASE_VERSION" --state absent
           python .github/scripts/check-crates-io-version.py --crate httpgenerator --version "$RELEASE_VERSION" --state absent
 
-      - name: Dry run: publish core
+      - name: Dry run - publish core
         run: cargo publish --locked --dry-run --allow-dirty -p httpgenerator-core
 
   publish-crates:
@@ -387,7 +387,7 @@ jobs:
         shell: bash
         run: python .github/scripts/check-crates-io-version.py --crate httpgenerator-core --version "$RELEASE_VERSION" --state present --retries 30 --delay-seconds 10
 
-      - name: Dry run: publish httpgenerator-openapi
+      - name: Dry run - publish httpgenerator-openapi
         run: cargo publish --locked --dry-run --allow-dirty -p httpgenerator-openapi
 
       - name: Publish httpgenerator-openapi
@@ -397,7 +397,7 @@ jobs:
         shell: bash
         run: python .github/scripts/check-crates-io-version.py --crate httpgenerator-openapi --version "$RELEASE_VERSION" --state present --retries 30 --delay-seconds 10
 
-      - name: Dry run: publish httpgenerator
+      - name: Dry run - publish httpgenerator
         run: cargo publish --locked --dry-run --allow-dirty -p httpgenerator
 
       - name: Publish httpgenerator

--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -358,8 +358,12 @@ jobs:
           python .github/scripts/check-crates-io-version.py --crate httpgenerator-openapi --version "$RELEASE_VERSION" --state absent
           python .github/scripts/check-crates-io-version.py --crate httpgenerator --version "$RELEASE_VERSION" --state absent
 
-      - name: Dry run - publish core
-        run: cargo publish --dry-run --allow-dirty -p httpgenerator-core
+      - name: Run package validation and dry run - publish core
+        run: |
+          # Validate dependents packages locally for manifest issues
+          cargo package --allow-dirty -p httpgenerator-openapi
+          cargo package --allow-dirty -p httpgenerator
+          cargo publish --dry-run --allow-dirty -p httpgenerator-core
 
   publish-crates:
     name: Publish crates.io packages
@@ -385,7 +389,7 @@ jobs:
 
       - name: Wait for httpgenerator-core on crates.io
         shell: bash
-        run: python .github/scripts/check-crates-io-version.py --crate httpgenerator-core --version "$RELEASE_VERSION" --state present --retries 30 --delay-seconds 10
+        run: python .github/scripts/check-crates-io-version.py --crate httpgenerator-core --version "$RELEASE_VERSION" --state present --retries 60 --delay-seconds 10
 
       - name: Dry run - publish httpgenerator-openapi
         run: cargo publish --dry-run --allow-dirty -p httpgenerator-openapi
@@ -395,7 +399,7 @@ jobs:
 
       - name: Wait for httpgenerator-openapi on crates.io
         shell: bash
-        run: python .github/scripts/check-crates-io-version.py --crate httpgenerator-openapi --version "$RELEASE_VERSION" --state present --retries 30 --delay-seconds 10
+        run: python .github/scripts/check-crates-io-version.py --crate httpgenerator-openapi --version "$RELEASE_VERSION" --state present --retries 60 --delay-seconds 10
 
       - name: Dry run - publish httpgenerator
         run: cargo publish --dry-run --allow-dirty -p httpgenerator

--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -28,7 +28,7 @@ jobs:
         shell: pwsh
 
       - name: Build Rust CLI
-        run: cargo build --release -p httpgenerator-cli
+        run: cargo build --release -p httpgenerator
 
       - name: Bundle Rust CLI
         run: Copy-Item target\release\httpgenerator.exe src/dotnet/HttpGenerator.VSIX/httpgenerator.exe -Force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,4 +14,5 @@ jobs:
     uses: ./.github/workflows/release-template.yml
     with:
       version: 1.1.0
+      publish-crates: true
     secrets: inherit

--- a/.github/workflows/template-url.yml
+++ b/.github/workflows/template-url.yml
@@ -30,7 +30,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build Rust CLI
-        run: cargo build --locked --release -p httpgenerator-cli
+        run: cargo build --locked --release -p httpgenerator
 
       - name: Generate code
         run: '& $env:GENERATOR_COMMAND $env:OPENAPI_SOURCE --no-logging'

--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -30,3 +30,15 @@
 - Validation confirmed in this session: `cargo test`, `dotnet build src\dotnet\HttpGenerator.sln -c Release`, `dotnet test src\dotnet\HttpGenerator.sln -c Release`, `test\smoke-tests.ps1`, and `npm ci` + `npm run compile` in `src\VSCode`.
 - Non-blocking follow-up from review: stale old-path references may still exist in some `.squad\` notes/history, so internal guidance should keep converging on the canonical layout.
 - Session directive: all spawned agents used GPT-5.4 for this session only.
+
+### crates.io Validation Sweep (2026-05-05)
+- The expected validation matrix on the Rust-first branch is green for `cargo test`, `dotnet build src\dotnet\HttpGenerator.slnx --configuration Release`, `dotnet test src\dotnet\HttpGenerator.slnx --configuration Release`, and `test\smoke-tests.ps1`.
+- `test\smoke-tests.ps1` must anchor execution to `$PSScriptRoot` so the root entrypoint actually exercises `test\OpenAPI\**` instead of silently skipping the fixture matrix.
+- Pre-publish Cargo validation needs two passes when the branch is intentionally dirty: first record the clean-worktree failure, then rerun with `--allow-dirty` to isolate real packaging issues from the expected CI/version-injection dirtiness gate.
+- `httpgenerator-core` currently passes both `cargo package --allow-dirty` and `cargo publish --dry-run --allow-dirty`.
+- `httpgenerator-openapi` and `httpgenerator` currently fail publish-style validation for the expected pre-publish reason: Cargo tries to resolve `httpgenerator-core` from crates.io during package preparation, and that crate/version is not published yet.
+- Key validation-facing files for this area: root `Cargo.toml`, per-crate manifests under `src\rust\httpgenerator-*\Cargo.toml`, `.github\workflows\build.yml`, `.github\workflows\release-template.yml`, and `test\smoke-tests.ps1`.
+
+### Team Closeout — crates.io publishing (2026-05-05)
+- Ripley signed off on the crates.io path as release-ready once Hicks' metadata/workflow changes and Hudson's docs updates aligned with the validation evidence.
+- The lasting tester-facing rule is to separate expected pre-publish dependency-order failures from true regressions and keep smoke execution rooted at `$PSScriptRoot`.

--- a/.squad/agents/hicks/history.md
+++ b/.squad/agents/hicks/history.md
@@ -32,6 +32,18 @@
 
 ## Learnings
 
+### Release Workflow crates.io Path (2026-05-05)
+- Stable crates.io publication now lives in `.github\workflows\release-template.yml` behind a reusable `publish-crates` boolean input, with `.github\workflows\release.yml` opting in and preview callers staying artifact-only by default.
+- Shared Rust release version injection is handled by `.github\scripts\set-rust-workspace-version.py`, which rewrites every `version = "0.1.0"` anchor in the root `Cargo.toml` so `[workspace.package]` and publish-safe sibling dependency pins stay aligned.
+- crates.io sequencing is `httpgenerator-core` → `httpgenerator-openapi` → `httpgenerator`, and `.github\scripts\check-crates-io-version.py` polls crates.io between publishes so downstream crates wait for the newly published dependency version instead of relying on a fixed sleep.
+- CI publish-readiness coverage now includes `.github\workflows\release.yml`, `.github\workflows\release-template.yml`, and `.github\scripts\**`; `build.yml` validates the version-injection helper with a core `cargo publish --dry-run` plus downstream `cargo check`.
+
+### crates.io Metadata & Workspace Wiring (2026-05-05)
+- Ripley's packaging gate is now the governing rule for Rust publish work: keep Edition 2024, `rust-version = "1.85"`, publish `httpgenerator`, `httpgenerator-core`, and `httpgenerator-openapi`, and keep `src\rust\httpgenerator-compat` private with `publish = false`.
+- Publish-safe sibling crate wiring belongs in the root workspace manifest: `Cargo.toml` should carry `{ version = "0.1.0", path = "src/rust/..." }` for public internal dependencies so local workspace builds still work while packaged crates remain valid for crates.io.
+- Public crate metadata now lives in the per-crate manifests and crate-local README files at `src\rust\httpgenerator-cli\README.md`, `src\rust\httpgenerator-core\README.md`, and `src\rust\httpgenerator-openapi\README.md`.
+- Release-time version injection must update every `version = "0.1.0"` anchor in the root `Cargo.toml`, not just `[workspace.package].version`, otherwise internal dependency pins drift once publishable crates stop being path-only.
+
 ### Source Layout Migration Closeout (2026-05-01)
 - The layout move succeeded because the contract was preserved at the repo root: `Cargo.toml` stayed the Rust entrypoint, `.NET` commands still run from the root while targeting `src\dotnet\HttpGenerator.sln`, and host tooling still resolves repo-root `target\debug` / `target\release` outputs.
 - Path fixes had to cover more than manifests: moved Rust crates needed deeper fixture-relative paths, compatibility-runner references had to target `src\dotnet`, and `src\dotnet\HttpGenerator.VSIX\HttpGeneratorCli.cs` needed one extra parent climb to keep development-time probing correct.
@@ -39,3 +51,19 @@
 - Root validation that passed after the move: `cargo test`, `dotnet build src\dotnet\HttpGenerator.sln -c Release`, `dotnet test src\dotnet\HttpGenerator.sln -c Release`, `test\smoke-tests.ps1`, and `dotnet run --project src\dotnet\HttpGenerator\HttpGenerator.csproj -- test\OpenAPI\v3.0\petstore.json --output .\artifacts\http-out --no-logging`.
 - Remaining known issue is pre-existing and unrelated to the move: VS Code packaging via `vsce --target` still requires `engines.vscode >= 1.61` while `package.json` declares `^1.50.0`.
 - Session directive: all spawned agents used GPT-5.4 for this session only.
+
+### Crates.io Publishing Readiness Assessment (2025-01-15)
+- **Publishable crates identified:** httpgenerator-core (normalization + rendering) and httpgenerator-openapi (OpenAPI parsing layer) have clean public APIs and zero workspace/CLI-specific dependencies; both are fully standalone libraries suitable for crates.io.
+- **Non-publishable:** httpgenerator-cli (binary entry point with Azure auth, telemetry, CLI args) and httpgenerator-compat (internal differential testing harness) must have `publish = false`.
+- **Critical blocker:** Root `Cargo.toml` has `edition = "2024"` which is invalid (Rust editions are 2015, 2018, 2021 only). Will fail crates.io validation. Must be changed to `edition = "2021"`.
+- **Missing metadata:** All crates lack description, authors, documentation, homepage, categories, keywords, readme, rust-version fields. Per-crate README.md files don't exist.
+- **Workspace compatibility:** Root workspace setup is compatible with crates.io publishing (resolver = "2", workspace.package inheritance, path-based members all supported). Dry-run validation must be added to CI/CD before actual publish.
+- **Release workflow gap:** Current release-template.yml builds CLI archives and VSIX packages but has no `cargo publish` steps. Must add new `publish-crates` job that publishes core before openapi (due to openapi dependency on core) with 3-5 minute propagation wait.
+- **MSRV strategy:** No `rust-version` field in workspace. Recommend `rust-version = "1.70"` (mid-2023, widely available, mature). Add MSRV validation to build.yml (`cargo +1.70 build`).
+- **Account setup:** Requires crates.io account + API token, which is external dependency (not in scope of analysis). Token should be added as CARGO_REGISTRY_TOKEN GitHub secret.
+- **Effort estimate:** 5–6 hours total (metadata 1h, documentation 1.5h, CI/CD 1.5h, testing 0.5h, external setup 0.5h).
+- The earlier crates.io readiness checklist and workflow plan were merged into `.squad\decisions.md` during the 2026-05-05 session closeout.
+
+### Team Closeout — crates.io publishing (2026-05-05)
+- Ripley's packaging gate and final approval are now the governing constraints for future Rust publish work in this repo.
+- Hudson aligned the user-facing install/docs story and Bishop confirmed the release validation matrix plus the `$PSScriptRoot` smoke-test anchor.

--- a/.squad/agents/hudson/history.md
+++ b/.squad/agents/hudson/history.md
@@ -32,3 +32,32 @@ CLI tool + VS extensions for generating `.http` files from OpenAPI specs.
 - The main docs surfaces that needed updates for the move were `README.md`, `CONTRIBUTING.md`, `.github\copilot-instructions.md`, `docs\README.md`, `docs\index.html`, `docs\Marketplace.md`, and `src\dotnet\HttpGenerator\README.md`.
 - Cross-agent closeout: Hicks preserved repo-root entrypoints and runtime lookup, Bishop confirmed validation/release matrix continuity, and Ripley approved the migration once the path-bearing active surfaces were clean.
 - Session directive: all spawned agents used GPT-5.4 for this session only.
+
+### Crates.io Publishing Pattern Analysis (2026-05-DD)
+- **Objective**: Extract patterns from `christianhelle/httprunner` and `christianhelle/azdocli` to guide httpgenerator crates.io publishing.
+- **Key findings**:
+  - Both repos use single `VERSION` env var in GitHub Actions workflow, injected via PowerShell to `Cargo.toml` before publish
+  - Both use `cargo publish --allow-dirty --token ${{ secrets.CRATES_TOKEN }}` for authentication
+  - httprunner (multi-crate) publishes core + CLI sequentially in same job; azdocli (single crate) publishes in standalone job
+  - httprunner updates per-crate README.md with version; azdocli does not
+  - No reference repos have .NET co-release; Rust CLI is isolated from legacy distribution
+- **Httpgenerator applicability**:
+  - ✅ Version injection pattern works identically (same workspace + per-crate Cargo.toml structure as httprunner)
+  - ✅ Multi-crate sequential publish fits 3-crate workspace (core → openapi → cli dependency chain)
+  - ✅ Token-based auth via CRATES_TOKEN secret is standard practice
+  - ⚠️ Decision needed: Publish httpgenerator-openapi and httpgenerator-core as public crates, or CLI-only?
+  - ⚠️ Version source strategy: httprunner uses `0.9.${{ github.run_number }}` (incremental), azdocli hardcodes constant
+- **Documentation checklist** (for future release workflow):
+  - Add CONTRIBUTING.md section on crates.io prerequisites (token setup, permissions)
+  - Link to crates.io package pages from README once released
+  - Consider adding per-crate README.md files if libraries are intended for downstream use
+- The reference-repo pattern study (httprunner + azdocli) was merged into `.squad\decisions.md` during the 2026-05-05 crates.io publishing closeout.
+
+### Crates.io Install Guidance Sweep (2026-05-05)
+- Ripley's packaging gate makes three crates public (`httpgenerator`, `httpgenerator-core`, `httpgenerator-openapi`) and keeps `src\rust\httpgenerator-compat` private with `publish = false`; docs should mirror that split exactly.
+- User-facing install guidance now needs a three-lane explanation: crates.io for Rust-native installs (`cargo install httpgenerator` for published releases), GitHub Releases for prebuilt standalone CLI archives, and Marketplace / VSIX packages for editor extensions that bundle native binaries.
+- The main surfaces for this message are `README.md`, `docs\index.html`, and `docs\README.md`; extension sections should also remind users that Cargo-installed binaries can be reused through `PATH`, `HTTPGENERATOR_PATH`, or `http-file-generator.executablePath`.
+
+### Team Closeout — crates.io publishing (2026-05-05)
+- Ripley approved the public/private crate split and release-readiness gate, while Hicks encoded ordered crates.io publication in the reusable workflow.
+- Bishop's validation closeout means the docs can safely describe crates.io as first-class while still calling out the expected pre-publish dry-run limitation.

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -32,3 +32,38 @@
 - Cross-agent closeout: Hicks landed the move and runtime rewrites, Bishop retargeted validation/release paths without changing matrix shape, Hudson updated the contributor/user-facing docs, and the migration passed the full validation set (`cargo test`, `dotnet build ...`, `dotnet test ...`, `test\smoke-tests.ps1`, `npm ci` + `npm run compile` in `src\VSCode`).
 - Only non-blocking follow-up after approval was stale old-path guidance inside `.squad\`; internal notes should keep converging on `src\rust` and `src\dotnet`.
 - Session directive: all spawned agents used GPT-5.4 for this session only.
+
+### Crates.io Publishing Readiness Investigation (2026-05-XX)
+- **Workspace structure:** Correct for publishing (CLI binary + 3 libraries; httpgenerator-compat is test-only)
+- **Critical blocker:** Edition specified as `"2024"` (invalid; must be `"2021"` or similar recognized edition). Blocks all crates.io submissions.
+- **Missing metadata:** All 4 crates lack `description`, `homepage`, `documentation`, `authors`, `keywords`, `categories` fields. Crates.io requires at minimum `description`; others improve discoverability.
+- **Binary vs library decision pending:** Architectural choice needed on whether to publish CLI to crates.io (for `cargo install`) or continue GitHub Releases only. Option C (Both) recommended for maximum user choice; adds ~5 min to release workflow.
+- **Library publication:** httpgenerator-core and httpgenerator-openapi are suitable for publication (stable public APIs, clean external dependency lists). httpgenerator-compat should be marked `publish = false` (test harness only).
+- **Dependency ordering:** Release workflow must publish in order: core → openapi → cli. Current release-template.yml has no `cargo publish` steps.
+- **Release workflow gaps:** Missing `cargo publish --dry-run` validation, missing CARGO_REGISTRY_TOKEN setup, missing publish steps in sequential order with delays for crates.io indexing.
+- **Documentation:** README lacks library usage guidance; no lib.rs root docs in crates. Need crate-level documentation comments and module examples.
+- **Versioning:** Currently 0.1.0 with manual sed/PowerShell updates. Semver strategy undefined (0.x.y vs 1.0.0 transition). Recommend staying in 0.x.y until APIs are stable.
+- The initial crates.io gap analysis (architecture, blockers, metadata completeness, and release workflow impact) was merged into `.squad\decisions.md` during the 2026-05-05 session closeout.
+
+### Crates.io Packaging Decision Gate (2026-05-05)
+- Rust 2024 is valid now; the Edition Guide pegs Rust 2024 to Rust 1.85. The earlier "2024 is invalid" assumption is stale and should not drive packaging decisions anymore.
+- Accepted public crate set: `httpgenerator` (CLI crate name for `cargo install httpgenerator`), `httpgenerator-core`, and `httpgenerator-openapi`. `src\rust\httpgenerator-compat` remains internal only with `publish = false`.
+- Canonical URL split for crates: `homepage = https://christianhelle.github.io/httpgenerator/` for the human-facing product surface, and `documentation = https://docs.rs/<crate>` for API docs on each public crate.
+- Direct decision-encoding paths touched: `Cargo.toml`, `src\rust\httpgenerator-{core,openapi,cli,compat}\Cargo.toml`, workflow/package-call surfaces that build by package name, and the merged decision record in `.squad\decisions.md`.
+
+### Final Crates.io Publishing Reviewer Gate (2026-05-05)
+- Final verdict: **approved / release-ready** for the crates.io implementation. No blocker-level defects found against the approved plan or the supplied validation evidence.
+- Expected limitation remains explicit: `cargo package` / `cargo publish --dry-run` is only expected to pass for `httpgenerator-core` before publication; downstream `httpgenerator-openapi` and `httpgenerator` dry-runs will fail until the sibling dependency version becomes visible on crates.io.
+- Publish sequencing is now encoded where it matters: `.github\workflows\release-template.yml` gates crates behind `publish-crates`, validates the token, publishes after artifact jobs, and publishes in order `httpgenerator-core` → `httpgenerator-openapi` → `httpgenerator` with crates.io polling between steps.
+- Metadata/docs contract is coherent across root and crate surfaces: root `Cargo.toml`, `src\rust\httpgenerator-{core,openapi,cli,compat}\Cargo.toml`, crate READMEs, `README.md`, `docs\README.md`, and `docs\index.html` all align on the public crate set, docs.rs/homepage split, and the private status of `httpgenerator-compat`.
+- Validation contract to remember for future reviews: `cargo test`, `dotnet build src\dotnet\HttpGenerator.slnx -c Release`, `dotnet test src\dotnet\HttpGenerator.slnx -c Release`, and `test\smoke-tests.ps1`; smoke correctness depends on the repo-root entrypoint staying anchored to `$PSScriptRoot`.
+
+## Governance
+
+- All meaningful changes require team consensus
+- Document architectural decisions here
+- Keep history focused on work, decisions focused on direction
+
+### Team Closeout — crates.io publishing (2026-05-05)
+- Hicks, Hudson, and Bishop cleared the implementation, docs, and validation tracks behind the packaging gate; final reviewer verdict stayed release-ready.
+- Expected publish-order limitation is now an explicit approved condition: downstream dry-runs wait for `httpgenerator-core` visibility on crates.io.

--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -17,3 +17,7 @@ Scribe maintains `.squad` memory: orchestration logs, session logs, decision mer
 - Logged the session in `.squad\log\` and merged the current decision inbox into `decisions.md`, then cleared `.squad\decisions\inbox\`.
 - Refreshed affected agent histories and summarized oversized history files into compact core context so internal notes stay useful after the source-layout migration.
 - Session directive: all spawned agents used GPT-5.4 for this session only.
+
+### Crates.io Publishing Session Closeout (2026-05-05)
+- Recorded orchestration outcomes for Ripley, Hicks, Hudson, and Bishop under `.squad\orchestration-log\` using UTC ISO-style timestamps.
+- Logged the session, merged the current decision inbox into `decisions.md`, cleared `.squad\decisions\inbox\`, and captured the GPT-5.5 session directive plus the crates.io packaging/workflow/docs/validation/release-readiness decisions.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -16,12 +16,10 @@
 - VSIX SDK updates isolated from main solution track
 - ~~xUnit stays on legacy family (v3 migration deferred)~~ → **Superseded:** xUnit v3 migration pulled forward by Atc.Test 2.x dependency (PR #340, 2026-03-20)
 - Use Windows PowerShell smoke tests (`test\smoke-tests.ps1`) for Windows validation
-**Reference:** `.squad/decisions/inbox/ripley-dependency-refresh-plan.md`, `.squad/log/20260320-dependency-refresh-plan.md`
 
 ### 2026-03-20: Baseline Validation & Test Strategy
 **By:** Bishop (Tester)
 **What:** 4-stage validation split across planned PRs: (1) metadata/CLI patch, (2) test infrastructure, (3) OpenAPI migration, (4) final regression. Final regression matrix covers v2.0/v3.0/v3.1, JSON/YAML, all 3 output types, custom headers, validation modes.
-**Reference:** `.squad/decisions/inbox/bishop-regression-plan.md`, `.squad/decisions/inbox/bishop-validation-fast.md`
 
 ### 2026-03-20: PR Cascade Review Verdict
 **By:** Ripley (Lead)
@@ -31,7 +29,6 @@
 - **PR #322:** ❌ REJECTED (cascading failure due to PR #321 branch contamination)
 **Root Cause:** PR #321 branch content diverged from intent; likely rebase error or branch created from wrong base.
 **Required Actions:** Recreate PR #321 with correct filename deduplication logic (HashSet + suffix appending).
-**Reference:** `.squad/decisions/inbox/ripley-cascade-merge-313-314-323.md`
 
 ### 2026-03-20: NuGet Audit & OpenAPI v3 Breaking-Change Mapping
 **By:** Hicks (Core Dev)
@@ -44,7 +41,6 @@
 - Serialization: sync → async (SerializeAsYamlAsync)
 - Null-safety: v3 no longer auto-initializes collections
 **VSIX Constraint:** dotnet list fails for VSIX project (needs VS/MSBuild environment); VSIX validation deferred to real VS environment.
-**Reference:** `.squad/decisions/inbox/hicks-nuget-audit.md`
 
 ### 2026-03-20: Release & Documentation Impact Assessment
 **By:** Hudson (DevRel/Docs)
@@ -54,13 +50,11 @@
 - Update README if --skip-validation requirement changes post-migration
 - Verify CLI examples work with new parser
 - Prioritize local fixture coverage over remote URL tests
-**Reference:** `.squad/decisions/inbox/hudson-release-impact.md`
 
 ### 2026-03-20: User Directive — Feature Branch & PR Workflow
 **By:** Christian Helle (via Copilot CLI)
 **What:** Plan and execute dependency updates in small chunks with small, frequent commits; never work directly on main; always use feature/fix branches and pull requests; have the squad review, approve, and merge PRs using regular merge commits (not squash or rebase).
 **Why:** Ensure clean, reviewable git history and staged implementation with clear checkpoints.
-**Reference:** `.squad/decisions/inbox/copilot-directive-20260320T124038Z.md`
 
 ### 2026-03-20: PR #338 — Spectre.Console.Cli 0.53.1 Upgrade (deps-003)
 **By:** Ripley (Lead), Hicks (Core Dev)
@@ -87,7 +81,6 @@
   - **PR #343:** Left open, clarified as rejected pending new-author revision (Bishop's security/coverage gates stand)
   - **Issue #331:** Blocked pending corrected deps-005 revision from non-Hicks author
 **Key Principle:** Reviewer rejection triggers author lockout. Next revision of rejected work must come from different team member to prevent author fixup loops and maintain review discipline.
-**Reference:** `.squad/decisions/inbox/ripley-cleanup-pr-343-344.md`
 
 ### 2026-03-20: Code Coverage Exclusion Audit (Hicks)
 **By:** Hicks (Core Dev)
@@ -165,6 +158,42 @@
 **By:** Christian Helle (via Copilot CLI)
 **What:** All spawned agents in this session must use GPT-5.4.
 **Why:** Session-only user directive for consistent agent execution.
+
+### 2026-05-05: Session Directive — Spawned Agents Use GPT-5.5
+**By:** Christian Helle (via Copilot CLI)
+**What:** Have all spawned agents use GPT-5.5 for the rest of this session only.
+**Why:** Session-only user directive for consistent agent execution.
+**Supersedes:** 2026-05-01 session directive to use GPT-5.4.
+
+### 2026-05-05: Crates.io Packaging Gate
+**By:** Ripley (Lead)
+**What:** Keep Rust Edition 2024, set shared `rust-version = "1.85"`, publish `httpgenerator`, `httpgenerator-core`, and `httpgenerator-openapi`, keep `src\rust\httpgenerator-compat` private with `publish = false`, and use GitHub Pages for homepage plus docs.rs for per-crate documentation.
+**Why:** This preserves the Rust-first product direction, keeps `cargo install httpgenerator` clean, and aligns crate metadata with the canonical product/docs surfaces.
+
+### 2026-05-05: Publish-safe Workspace Dependency Wiring
+**By:** Hicks (Core Dev)
+**What:** Internal public-crate dependencies must carry both `path` and `version` in the root workspace manifest, and release-time version injection must replace every `version = "0.1.0"` anchor in the root `Cargo.toml`.
+**Why:** Local workspace builds stay ergonomic while packaged crates remain valid for crates.io and release-time version pins stay aligned.
+
+### 2026-05-05: Release Workflow crates.io Publication Path
+**By:** Hicks (Core Dev)
+**What:** Wire crates.io publication into the reusable release workflow behind `publish-crates`, enable it for stable `release.yml`, keep preview/template callers artifact-only by default, require `CARGO_REGISTRY_TOKEN`, and publish in dependency order `httpgenerator-core` → `httpgenerator-openapi` → `httpgenerator` with crates.io visibility polling between steps.
+**Why:** Stable releases should publish crates automatically without risking preview-package pushes or brittle fixed sleeps.
+
+### 2026-05-05: crates.io Documentation Distribution Matrix
+**By:** Hudson (DevRel/Docs)
+**What:** Treat crates.io as a first-class Rust install/library channel, keep GitHub Releases as the source of prebuilt CLI archives, and keep VS Code / Visual Studio extensions documented as bundled-binary Marketplace / VSIX distributions.
+**Why:** Users need the install channels explained as complementary instead of assuming the extensions fetch their runtime from crates.io.
+
+### 2026-05-05: Validation Contract for crates.io Publishing
+**By:** Bishop (Tester)
+**What:** Treat dirty-worktree publish failures without `--allow-dirty` separately from expected downstream crates.io resolution failures, keep the smoke-test root entrypoint anchored to `$PSScriptRoot`, and preserve publish sequencing `httpgenerator-core` → `httpgenerator-openapi` → `httpgenerator`.
+**Why:** Validation reporting should distinguish true regressions from the known pre-publish dependency-order limitation.
+
+### 2026-05-05: Crates.io Publishing Release Readiness
+**By:** Ripley (Lead), Hicks (Core Dev), Hudson (DevRel/Docs), Bishop (Tester)
+**What:** Approved the crates.io publishing implementation as release-ready after green validation (`cargo test`, `dotnet build src\dotnet\HttpGenerator.slnx -c Release`, `dotnet test src\dotnet\HttpGenerator.slnx -c Release`, `test\smoke-tests.ps1`) and aligned metadata, workflow, and docs.
+**Expected limitation:** Only `httpgenerator-core` can pass local publish-style dry-runs before first publication; `httpgenerator-openapi` and `httpgenerator` must wait for crates.io visibility of the newly published dependency version.
 
 ## Governance
 

--- a/.squad/log/2026-05-05T16-03-24Z-crates-io-publishing.md
+++ b/.squad/log/2026-05-05T16-03-24Z-crates-io-publishing.md
@@ -1,0 +1,7 @@
+# Session Log — crates.io publishing
+
+- **Timestamp:** 2026-05-05T16:03:24Z
+- **Scope:** Crates.io publishing readiness closeout for the Rust-first workspace.
+- **Team outcome:** Ripley approved the release path; Hicks shipped metadata/workflow support; Hudson aligned install/distribution docs; Bishop validated the full matrix and anchored smoke tests to `$PSScriptRoot`.
+- **Decision merge:** Packaging, workflow, docs, validation, release-readiness, and the GPT-5.5 session directive were folded into `decisions.md`; inbox files were cleared after merge.
+- **Expected limitation:** Before the first crates.io release, only `httpgenerator-core` can complete publish-style dry-runs locally because downstream crates depend on that version becoming visible on crates.io first.

--- a/.squad/orchestration-log/2026-05-05T16-03-24Z-bishop.md
+++ b/.squad/orchestration-log/2026-05-05T16-03-24Z-bishop.md
@@ -1,0 +1,6 @@
+# Orchestration Log — Bishop
+
+- **Timestamp:** 2026-05-05T16:03:24Z
+- **Role:** Validation
+- **Outcome:** Re-ran `cargo test`, `dotnet build src\dotnet\HttpGenerator.slnx -c Release`, `dotnet test src\dotnet\HttpGenerator.slnx -c Release`, and `test\smoke-tests.ps1`, then fixed the validation-side smoke test anchoring to `$PSScriptRoot`.
+- **Carry-forward:** Only `httpgenerator-core` is expected to pass publish-style dry-runs before first publication; downstream package prep waits on crates.io visibility.

--- a/.squad/orchestration-log/2026-05-05T16-03-24Z-hicks.md
+++ b/.squad/orchestration-log/2026-05-05T16-03-24Z-hicks.md
@@ -1,0 +1,6 @@
+# Orchestration Log — Hicks
+
+- **Timestamp:** 2026-05-05T16:03:24Z
+- **Role:** Core implementation
+- **Outcome:** Landed Cargo metadata, public crate README surfaces, publish-safe sibling dependency wiring, and reusable workflow support for ordered crates.io publishing with shared workspace version injection and crates.io polling helpers.
+- **Carry-forward:** The reusable release path now publishes only when `publish-crates` is enabled and a `CARGO_REGISTRY_TOKEN` secret is present.

--- a/.squad/orchestration-log/2026-05-05T16-03-24Z-hudson.md
+++ b/.squad/orchestration-log/2026-05-05T16-03-24Z-hudson.md
@@ -1,0 +1,6 @@
+# Orchestration Log — Hudson
+
+- **Timestamp:** 2026-05-05T16:03:24Z
+- **Role:** DevRel / docs
+- **Outcome:** Updated `README.md`, `docs\README.md`, and `docs\index.html` so crates.io is a first-class install path and the public/private crate split plus distribution matrix stay explicit.
+- **Carry-forward:** Docs now distinguish Cargo install, GitHub Releases archives, and bundled extension distribution channels.

--- a/.squad/orchestration-log/2026-05-05T16-03-24Z-ripley.md
+++ b/.squad/orchestration-log/2026-05-05T16-03-24Z-ripley.md
@@ -1,0 +1,6 @@
+# Orchestration Log — Ripley
+
+- **Timestamp:** 2026-05-05T16:03:24Z
+- **Role:** Lead / reviewer
+- **Outcome:** Investigated crates.io readiness, set the packaging gate (Edition 2024, `rust-version = 1.85`, public crates `httpgenerator`, `httpgenerator-core`, `httpgenerator-openapi`, private `httpgenerator-compat`), and closed with a release-ready approval.
+- **Carry-forward:** Downstream dry-runs remain expected to fail until `httpgenerator-core` is visible on crates.io; release automation now handles ordered publish + visibility polling.

--- a/.squad/skills/rust-crates-publishing/SKILL.md
+++ b/.squad/skills/rust-crates-publishing/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: "Rust Multi-Crate Publishing to crates.io"
+description: "Automated workflow patterns for publishing Rust crates to crates.io from GitHub Actions, including version injection, token auth, and multi-crate dependency ordering."
+domain: "release-automation, crates.io, cargo-publish"
+confidence: "high"
+source: "observed from httprunner and azdocli reference implementations"
+tools:
+  - name: "github-mcp-server"
+    description: "GitHub Actions workflow inspection and file fetching"
+    when: "Analyzing release workflows in reference repos"
+---
+
+## Context
+
+Rust projects published to crates.io require automation to handle version updates, multi-platform builds, and credential management. This skill captures proven patterns from two reference implementations (httprunner and azdocli) that apply to multi-crate workspaces like httpgenerator.
+
+## Patterns
+
+### 1. Version Injection via Environment Variable
+**Pattern**: Use a single `VERSION` env var in the GitHub Actions workflow, injected to `Cargo.toml` files before publishing.
+
+**Implementation**:
+```yaml
+env:
+  VERSION: 0.9.${{ github.run_number }}  # or hardcoded, or computed from git tags
+  
+jobs:
+  publish-crates:
+    steps:
+      - name: Update Version
+        shell: pwsh
+        run: |
+          $toml = (Get-Content -Path Cargo.toml -Raw) -replace 'version = "0.1.0"', 'version = "${{ env.VERSION }}"'
+          $toml | Set-Content -Path Cargo.toml
+```
+
+**Why this works**:
+- Single source of truth (env var) avoids version drift across multiple Cargo.toml files
+- PowerShell script is cross-platform compatible (Windows CI, Unix CI)
+- "0.1.0" placeholder is a convention; both reference repos start with it
+- Allows version to be computed, hardcoded, or parameterized without changing workflow structure
+
+**For multi-crate workspaces**: Apply sed/replace to each crate's Cargo.toml individually:
+```yaml
+$toml = (Get-Content -Path src/rust/httpgenerator-core/Cargo.toml -Raw) -replace 'version = "0.1.0"', 'version = "${{ env.VERSION }}"'
+$toml | Set-Content -Path src/rust/httpgenerator-core/Cargo.toml
+```
+
+**Workspace dependency variant**: If internal crates are declared once in the root `[workspace.dependencies]` table with both `path` and `version`, replace every `version = "0.1.0"` occurrence in the root `Cargo.toml` so the workspace package version and internal dependency pins stay aligned.
+
+### 2. Token-Based Authentication
+**Pattern**: Store `CRATES_TOKEN` as a GitHub Organization Secret, pass to `cargo publish` via `--token` flag.
+
+**Implementation**:
+```yaml
+- name: Publish to crates.io
+  run: cargo publish --allow-dirty --token ${{ secrets.CRATES_TOKEN }}
+  env:
+    CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}  # optional, redundant
+```
+
+**Prerequisites**:
+- Create account at crates.io
+- Generate API token from crates.io account settings
+- Store token as `CRATES_TOKEN` in GitHub Organization Secrets (or Repository Secrets if org-level is unavailable)
+- Document token setup in CONTRIBUTING.md
+
+**Note**: `--allow-dirty` is required because the workflow modifies Cargo.toml before publish; this is expected and safe in CI/CD.
+
+### 3. Multi-Crate Publishing with Dependency Ordering
+**Pattern**: Publish crates sequentially in dependency order (no parallel jobs for the same crate set).
+
+**Implementation**:
+```yaml
+publish-crates:
+  steps:
+    - name: Publish Core to crates.io
+      run: cargo publish --allow-dirty --token ${{ secrets.CRATES_TOKEN }} -p httpgenerator-core
+      
+    - name: Publish OpenAPI to crates.io (depends on core)
+      run: cargo publish --allow-dirty --token ${{ secrets.CRATES_TOKEN }} -p httpgenerator-openapi
+      
+    - name: Publish CLI to crates.io (depends on both)
+      run: cargo publish --allow-dirty --token ${{ secrets.CRATES_TOKEN }} -p httpgenerator
+```
+
+**Why sequential**:
+- crates.io index propagation takes ~1 min per publish
+- Sequential ensures downstream crates can resolve dependencies immediately
+- `cargo publish` with explicit `-p {crate}` targets specific workspace members
+
+### 4. Job Dependencies and Release Flow
+**Pattern**: Chain jobs to ensure builds complete before publishing; optionally gate publishing on GitHub Release creation.
+
+**Implementation (Sequential)**):
+```yaml
+jobs:
+  build:
+    # ... build binaries, create archives, upload artifacts
+
+  release:
+    needs: build
+    # ... download artifacts, create GitHub Release with assets
+
+  publish-crates:
+    needs: release  # Wait for GitHub Release before publishing to crates.io
+    # ... run cargo publish jobs
+```
+
+**Alternative (Parallel)**: All publish jobs depend on `build`, not `release` (faster, but less coupled to GitHub Release timing).
+
+**httpgenerator recommendation**: Use sequential (publish-crates depends on release) to ensure GitHub Releases are finalized before crates.io publication.
+
+### 4c. Validation Ladder for Dirty Release Branches
+**Pattern**: When validating crates.io readiness on a branch that already contains uncommitted release metadata or workflow edits, run publish-focused checks in two stages: first without `--allow-dirty` to capture the worktree gate, then with `--allow-dirty` to expose the real packaging result.
+
+**Why this works**:
+- Separates expected dirty-worktree failures from actual crates.io regressions
+- Mirrors CI/CD behavior where version injection intentionally dirties manifests before publish
+- Prevents the dirty-tree gate from hiding missing-registry-dependency failures in downstream crates
+
+**Httpgenerator example**:
+- `httpgenerator-core` passes `cargo package --allow-dirty` and `cargo publish --dry-run --allow-dirty`
+- `httpgenerator-openapi` and `httpgenerator` still fail until `httpgenerator-core` is available from crates.io for package verification
+
+**Interpretation rule**:
+- A failure that disappears with `--allow-dirty` is an expected release-workflow condition, not a product regression
+- A downstream "no matching package named ... found" against crates.io before sibling publication is an expected pre-publish blocker, not a branch regression
+
+### 4a. Reusable Workflow Opt-In for Stable Publishing
+**Pattern**: Put crates.io publication behind a `workflow_call` boolean input so stable release entrypoints can opt in while preview/dry-run callers reuse the same artifact jobs without publishing.
+
+**Implementation**:
+```yaml
+on:
+  workflow_call:
+    inputs:
+      publish-crates:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  publish-crates:
+    if: ${{ inputs.publish-crates }}
+```
+
+**Why this works**:
+- Keeps one canonical release workflow instead of forking artifact and publish logic
+- Prevents preview releases from accidentally publishing prerelease crate versions
+- Lets the stable caller (`release.yml`) opt in explicitly with `publish-crates: true`
+
+### 4b. Poll crates.io Instead of Sleeping Blindly
+**Pattern**: After publishing a dependency crate, poll the crates.io API until the new version is visible before dry-running/publishing downstream crates.
+
+**Implementation**:
+```bash
+python .github/scripts/check-crates-io-version.py \
+  --crate httpgenerator-core \
+  --version "$RELEASE_VERSION" \
+  --state present \
+  --retries 30 \
+  --delay-seconds 10
+```
+
+**Why this works**:
+- crates.io indexing latency varies; fixed sleeps are either flaky or wasteful
+- downstream `cargo publish --dry-run` only succeeds once the just-published dependency version is visible
+- the same helper can also assert a version is absent before starting publication
+
+### 5. README.md Version Anchors (Optional)
+**Pattern**: Update per-crate README files with published version, so install instructions always show latest.
+
+**Implementation**:
+```yaml
+- name: Update README with version
+  run: |
+    $readme = (Get-Content -Path src/rust/httpgenerator-core/README.md -Raw) -replace 'httpgenerator-core = "0.1.0"', 'httpgenerator-core = "${{ env.VERSION }}"'
+    $readme | Set-Content -Path src/rust/httpgenerator-core/README.md
+```
+
+**When to use**: Only if per-crate README files exist and contain version-pinned install instructions. httprunner does this; azdocli does not.
+
+### 6. User-Facing Distribution Matrix
+**Pattern**: Document crates.io, GitHub Releases, and editor extensions as complementary delivery channels instead of treating one as a full replacement for the others.
+
+**Implementation guidance**:
+- Position `cargo install <cli-crate>` as the Rust-native install path for published releases.
+- Keep GitHub Releases documented as the source for prebuilt CLI archives for users without a Rust toolchain.
+- Call out which crates are public libraries versus internal/private workspace crates.
+- Explicitly say that VS Code / Visual Studio extensions bundle native binaries and do not install the CLI from crates.io, even if they can reuse a Cargo-installed binary from `PATH` or an override setting.
+
+**Why this works**:
+- Prevents user confusion between package publishing and binary distribution.
+- Keeps install guidance accurate for both CLI-only users and extension users.
+- Gives downstream docs a stable template when a Rust-first repo still ships Marketplace / VSIX hosts.
+
+## Examples
+
+### Httprunner (4-crate workspace, 2 published)
+- Publishes `httprunner-core` + `httprunner` (CLI)
+- Uses `0.9.${{ github.run_number }}` versioning (auto-increments)
+- Updates both root and per-crate Cargo.toml files
+- Updates `src/core/README.md` with version
+- Also publishes Docker images in parallel (orthogonal jobs)
+
+### Azdocli (1-crate, multi-distribution)
+- Single crate, no workspace complexity
+- Uses hardcoded `VERSION: 0.4.1` (manual updates)
+- Publishes to crates.io, then generates Homebrew/Chocolatey/WinGet packages in parallel jobs
+
+### Httpgenerator (3-crate, cli-focused)
+- Should publish in order: core → openapi → httpgenerator
+- Consider using git tags for version source (e.g., `git describe --tags`)
+- Simpler than httprunner (no Docker), more complex than azdocli (3 crates vs 1)
+- Reusable workflow should default `publish-crates` to `false`; `release.yml` opts in for stable publication while preview callers keep artifact-only behavior
+- User-facing docs should explain the split this way:
+  - crates.io: `cargo install httpgenerator`
+  - GitHub Releases: prebuilt `httpgenerator-<version>-<platform>` archives
+  - VS Code / Visual Studio: extension packages that bundle native binaries
+  - Public crates: `httpgenerator`, `httpgenerator-core`, `httpgenerator-openapi`
+  - Private crate: `httpgenerator-compat`
+
+## Anti-Patterns
+
+**❌ Parallel crate publishing**: Publishing multiple interdependent crates in parallel jobs without waiting for crates.io index propagation.
+- **Fix**: Use sequential steps in single job, or add sleep/retry logic between parallel jobs.
+
+**❌ Hardcoding version in Cargo.toml**: Forgetting to inject version from workflow env var, or skipping per-crate Cargo.toml updates in workspace.
+- **Fix**: Template ALL Cargo.toml files (workspace root + all members) with "0.1.0" placeholder; replace in workflow.
+
+**❌ Path-only internal workspace dependencies for publishable crates**: Local builds work, but crates.io packages cannot resolve unpublished sibling crates.
+- **Fix**: Use `{ version = "0.1.0", path = "..." }` for publishable sibling crates, then update those version anchors during release automation.
+
+**❌ Omitting `--allow-dirty`**: Publishing fails with "working directory is not clean" error.
+- **Fix**: Include `--allow-dirty` when publishing from CI/CD after version injection.
+
+**❌ Missing token secret**: Using literal token in workflow file or committing token to git.
+- **Fix**: Store `CRATES_TOKEN` in GitHub Secrets, never in workflows or source code.
+
+**❌ Publishing before GitHub Release**: Publishing to crates.io before creating GitHub Release with binaries.
+- **Fix**: Create `release` job that depends on `build`, then `publish-crates` depends on `release`.
+
+**❌ Blind fixed sleeps between crates**: Sleeping 60–180 seconds and hoping crates.io has indexed the dependency.
+- **Fix**: Poll crates.io until the new version appears, then continue to the downstream crate.
+
+**❌ Conflating crates.io with extension delivery**: Telling users that VS Code or Visual Studio installs the CLI from crates.io.
+- **Fix**: State clearly that extensions ship bundled binaries and only optionally reuse a Cargo-installed binary via `PATH` or explicit configuration.
+
+## Decisions for Httpgenerator
+
+1. **All 3 crates public?** Publish `httpgenerator` (CLI crate name), `httpgenerator-core`, and `httpgenerator-openapi`. Keep `httpgenerator-compat` private with `publish = false`.
+
+2. **Edition/MSRV pairing?** Rust 2024 is valid as of Rust 1.85. Keep Edition 2024 if the repo is already on it, and make the corresponding `rust-version = "1.85"` promise explicit instead of downgrading based on stale pre-release guidance.
+
+3. **Homepage/docs split?** Use the GitHub Pages site (`https://christianhelle.github.io/httpgenerator/`) as the human-facing homepage and `https://docs.rs/<crate>` as the canonical per-crate API documentation URL.
+
+4. **Version source?** httprunner uses run number (0.9.NNN), azdocli hardcodes. Consider git tags for semantic versioning (e.g., `v1.0.0` → `1.0.0`).
+
+5. **Per-crate README?** httprunner updates src/core/README.md; azdocli does not. Defer unless per-crate install instructions are needed.
+
+6. **Job chaining?** Recommend sequential (publish-crates depends on release) to couple crates.io publication with GitHub Release finalization.
+
+## Decision Gate Notes
+
+- Do not assume `edition = "2024"` is invalid. That was true before stabilization, but Rust 2024 shipped in Rust 1.85.
+- For cargo-install ergonomics, the public CLI crate should be named `httpgenerator`; keeping `httpgenerator-cli` only as a folder name is fine.
+
+---
+
+**Reference Decision**: See `.squad/decisions/inbox/hudson-crates-publishing-patterns.md` for analysis of httprunner and azdocli implementations.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpgenerator-cli"
+name = "httpgenerator"
 version = "0.1.0"
 dependencies = [
  "azure_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 homepage = "https://christianhelle.github.io/httpgenerator/"
 license = "MIT"
 repository = "https://github.com/christianhelle/httpgenerator"
-rust-version = "1.85"
+rust-version = "1.95"
 version = "0.1.0"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,12 @@ members = [
 resolver = "2"
 
 [workspace.package]
+authors = ["Christian Helle"]
 edition = "2024"
+homepage = "https://christianhelle.github.io/httpgenerator/"
 license = "MIT"
 repository = "https://github.com/christianhelle/httpgenerator"
+rust-version = "1.85"
 version = "0.1.0"
 
 [workspace.dependencies]
@@ -18,8 +21,8 @@ azure_core = "0.35.0"
 azure_identity = "0.35.0"
 clap = { version = "4.5.53", features = ["derive"] }
 console = "0.16.3"
-httpgenerator-core = { path = "src/rust/httpgenerator-core" }
-httpgenerator-openapi = { path = "src/rust/httpgenerator-openapi" }
+httpgenerator-core = { version = "0.1.0", path = "src/rust/httpgenerator-core" }
+httpgenerator-openapi = { version = "0.1.0", path = "src/rust/httpgenerator-openapi" }
 openapiv3 = "2.2.0"
 openapiv3_1 = "0.1.5"
 pollster = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Generate .http files from OpenAPI specifications
 HTTP File Generator now ships as a Rust CLI plus thin IDE hosts.
 
 - **crates.io**: `cargo install httpgenerator`
-  - Best when you already have Rust and Cargo (Rust 1.85+) on your machine and want the canonical Rust ecosystem install path for published releases.
+  - Best when you already have Rust and Cargo (Rust 1.95+) on your machine and want the canonical Rust ecosystem install path for published releases.
   - The public crates.io surface is split into the end-user CLI crate `httpgenerator` plus the reusable library crates `httpgenerator-core` and `httpgenerator-openapi`.
 - **Standalone CLI**: download the platform-specific archive from [GitHub Releases](https://github.com/christianhelle/httpgenerator/releases) and place `httpgenerator` / `httpgenerator.exe` on `PATH`.
   - Best when you want a prebuilt binary without installing the Rust toolchain.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ crates.io complements rather than replaces the existing release channels. Use cr
 
 ### Repository layout
 
-- `src\rust` contains the Rust workspace crates (`httpgenerator-cli`, `httpgenerator-core`, `httpgenerator-openapi`, and `httpgenerator-compat`).
+- `src\rust` contains the Rust workspace crates (`httpgenerator`, `httpgenerator-core`, `httpgenerator-openapi`, and `httpgenerator-compat`); the CLI crate `httpgenerator` lives in the `src/rust/httpgenerator-cli` directory.
 - `src\dotnet` contains the legacy .NET CLI, core library, test suite, and Visual Studio VSIX host.
 - `src\vscode` contains the VS Code extension.
 - Root-level entrypoints are preserved: run Cargo commands from the repository root via `Cargo.toml`, target the moved .NET solutions with `src/dotnet/*.slnx`, and invoke VS Code packaging with `src\vscode\build.ps1`.

--- a/README.md
+++ b/README.md
@@ -25,15 +25,21 @@ Generate .http files from OpenAPI specifications
 
 HTTP File Generator now ships as a Rust CLI plus thin IDE hosts.
 
+- **crates.io**: `cargo install httpgenerator`
+  - Best when you already have Rust and Cargo (Rust 1.85+) on your machine and want the canonical Rust ecosystem install path for published releases.
+  - The public crates.io surface is split into the end-user CLI crate `httpgenerator` plus the reusable library crates `httpgenerator-core` and `httpgenerator-openapi`.
 - **Standalone CLI**: download the platform-specific archive from [GitHub Releases](https://github.com/christianhelle/httpgenerator/releases) and place `httpgenerator` / `httpgenerator.exe` on `PATH`.
+  - Best when you want a prebuilt binary without installing the Rust toolchain.
   - `httpgenerator-<version>-linux-x64.tar.gz`
   - `httpgenerator-<version>-darwin-x64.tar.gz`
   - `httpgenerator-<version>-win-x64.zip`
-- **Build locally**: `cargo build --release -p httpgenerator-cli`
+- **Build locally**: `cargo build --release -p httpgenerator`
 - **VS Code**: install the platform-specific `.vsix` for your OS and architecture. Each package bundles the native Rust CLI, and you can override it with `http-file-generator.executablePath`.
 - **Visual Studio 2022**: install the Visual Studio `.vsix`, which bundles `httpgenerator.exe`.
 
 The legacy `.NET` CLI remains in the repository as the migration oracle and compatibility host, but it is no longer the primary release path.
+
+crates.io complements rather than replaces the existing release channels. Use crates.io for Rust-native installation and library consumption, use GitHub Releases for prebuilt CLI archives, and use the VS Code / Visual Studio Marketplace packages when you want the editor hosts with their bundled binaries.
 
 ### Repository layout
 
@@ -41,6 +47,13 @@ The legacy `.NET` CLI remains in the repository as the migration oracle and comp
 - `src\dotnet` contains the legacy .NET CLI, core library, test suite, and Visual Studio VSIX host.
 - `src\vscode` contains the VS Code extension.
 - Root-level entrypoints are preserved: run Cargo commands from the repository root via `Cargo.toml`, target the moved .NET solutions with `src/dotnet/*.slnx`, and invoke VS Code packaging with `src\vscode\build.ps1`.
+
+### Public vs private Rust crates
+
+- `httpgenerator` is the public CLI crate and the package normal users install with `cargo install httpgenerator`.
+- `httpgenerator-core` is a public library crate for the normalized model and `.http` rendering pipeline.
+- `httpgenerator-openapi` is a public library crate for OpenAPI loading, parsing, version detection, and normalization.
+- `httpgenerator-compat` is an internal compatibility and differential-testing harness. It stays private and is not intended for crates.io distribution.
 
 ## Usage
 
@@ -246,7 +259,7 @@ No **support key** is generated when you opt out with `--no-logging`.
 
 The VS Code extension is now packaged per platform because it bundles the native Rust CLI.
 
-When `http-file-generator.executablePath` is empty, the extension looks for a bundled binary, repo-root workspace `target\debug` / `target\release` outputs, and finally `httpgenerator` on `PATH`.
+When `http-file-generator.executablePath` is empty, the extension looks for a bundled binary, repo-root workspace `target\debug` / `target\release` outputs, and finally `httpgenerator` on `PATH`. That means a Cargo-installed `httpgenerator` binary can also satisfy the extension if you prefer to manage the CLI yourself.
 
 ### Visual Studio 2022 Extension
 
@@ -258,7 +271,7 @@ From the **Tools** menu select **Generate .http files**
 
 This opens the main dialog which has similar input fields as the CLI tool and now shells out to the Rust `httpgenerator` executable.
 
-The Visual Studio extension resolves `httpgenerator.exe` from `HTTPGENERATOR_PATH`, the bundled VSIX payload, repo-root workspace `target\debug` / `target\release` outputs during development, or `PATH`.
+The Visual Studio extension resolves `httpgenerator.exe` from `HTTPGENERATOR_PATH`, the bundled VSIX payload, repo-root workspace `target\debug` / `target\release` outputs during development, or `PATH`. A Cargo-installed CLI can therefore be reused here as long as the binary is discoverable on `PATH` or via `HTTPGENERATOR_PATH`.
 
 ![Main dialog](https://github.com/christianhelle/httpgenerator/blob/main/images/vsix_httpgenerator_dialog.png?raw=true)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,10 @@ This directory contains the static documentation website for the HTTP File Gener
 
 The canonical source layout for the product now lives under `src\rust`, `src\dotnet`, and `src\vscode`; this `docs/` folder remains a root-level documentation surface alongside the preserved repo-root build entrypoints.
 
+The docs site is also the human-facing homepage referenced by the public Rust crates. Keep its installation guidance aligned with the root `README.md`: `cargo install httpgenerator` is the Rust ecosystem install path for published releases, GitHub Releases provide the prebuilt CLI archives, and the editor extensions continue distributing bundled native binaries through `.vsix` packages.
+
+The public crates are `httpgenerator`, `httpgenerator-core`, and `httpgenerator-openapi`. `httpgenerator-compat` is intentionally private and should not be presented as a user-installable crate.
+
 ## Files
 
 - `index.html` - Main documentation page with complete project information

--- a/docs/index.html
+++ b/docs/index.html
@@ -50,13 +50,16 @@
                 <h2 class="section-title">Installation</h2>
                 <p>HTTP File Generator now ships as a Rust CLI plus thin IDE hosts.</p>
                 <ul>
+                    <li>Install from <strong>crates.io</strong> with <code>cargo install httpgenerator</code> when you want the canonical Rust ecosystem install path for published releases.</li>
                     <li>Download a platform-specific CLI archive from <a href="https://github.com/christianhelle/httpgenerator/releases">GitHub Releases</a> and place <code>httpgenerator</code> / <code>httpgenerator.exe</code> on <code>PATH</code>.</li>
-                    <li>Build locally with <code>cargo build --release -p httpgenerator-cli</code>.</li>
+                    <li>Build locally with <code>cargo build --release -p httpgenerator</code>.</li>
                     <li>Install the platform-specific VS Code <code>.vsix</code>; each package bundles the native Rust CLI.</li>
                     <li>Install the Visual Studio 2022 <code>.vsix</code>; it bundles <code>httpgenerator.exe</code>.</li>
                 </ul>
                 <p>The legacy .NET CLI remains in the repository as the migration oracle and compatibility host, but it is no longer the primary release path.</p>
-                <p>The canonical source layout is <code>src\rust</code>, <code>src\dotnet</code>, and <code>src\VSCode</code>. Root entrypoints stay at the repository root, so Cargo commands still run from the root <code>Cargo.toml</code>, .NET commands still target <code>src/dotnet/*.slnx</code>, and VS Code packaging still runs through <code>src\VSCode\build.ps1</code>.</p>
+                <p>crates.io is the Rust-native install and library distribution path. GitHub Releases remain the source for prebuilt CLI archives, and the editor extensions continue shipping their own bundled native binaries through Marketplace / VSIX distribution.</p>
+                <p>The public crates are <code>httpgenerator</code> (CLI), <code>httpgenerator-core</code>, and <code>httpgenerator-openapi</code>. The <code>httpgenerator-compat</code> crate is an internal compatibility harness and is not published.</p>
+                <p>The canonical source layout is <code>src\rust</code>, <code>src\dotnet</code>, and <code>src\vscode</code>. Root entrypoints stay at the repository root, so Cargo commands still run from the root <code>Cargo.toml</code>, .NET commands still target <code>src/dotnet/*.slnx</code>, and VS Code packaging still runs through <code>src\vscode\build.ps1</code>.</p>
             </section>
 
             <!-- Usage Section -->
@@ -247,7 +250,7 @@ Support key: mbmbqvd</code></pre>
                     <img src="images/vsix_httpgenerator_dialog.png" alt="Main dialog" class="screenshot">
                 </div>
 
-                <p>The Visual Studio extension resolves <code>httpgenerator.exe</code> from <code>HTTPGENERATOR_PATH</code>, the bundled VSIX payload, repo-root workspace <code>target\debug</code> / <code>target\release</code> outputs during development, or <code>PATH</code>.</p>
+                <p>The Visual Studio extension resolves <code>httpgenerator.exe</code> from <code>HTTPGENERATOR_PATH</code>, the bundled VSIX payload, repo-root workspace <code>target\debug</code> / <code>target\release</code> outputs during development, or <code>PATH</code>. A Cargo-installed CLI can therefore be reused when you want the extension to target the same binary you use from the terminal.</p>
 
                 <p>You can supply Azure Entra ID tenant and scope settings by clicking on the <code>...</code> button beside the <strong>Authorization Headers</strong> input field. The Rust CLI acquires the access token during generation.</p>
                 <div class="image-container">

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -37,7 +37,7 @@ parts:
     plugin: rust
     source: .
     override-build: |
-      cargo build --release --package httpgenerator-cli
+      cargo build --release --package httpgenerator
       install -D -m755 target/release/httpgenerator $SNAPCRAFT_PART_INSTALL/bin/httpgenerator
     build-packages:
       - libssl-dev

--- a/src/rust/httpgenerator-cli/Cargo.toml
+++ b/src/rust/httpgenerator-cli/Cargo.toml
@@ -1,9 +1,20 @@
 [package]
-name = "httpgenerator-cli"
+name = "httpgenerator"
+authors.workspace = true
 version.workspace = true
 edition.workspace = true
+description = "Generate .http files from OpenAPI specifications"
+homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
+documentation = "https://docs.rs/httpgenerator"
+readme = "README.md"
+keywords = ["openapi", "http", "generator", "cli", "rest"]
+categories = ["command-line-utilities", "development-tools"]
+
+[lib]
+name = "httpgenerator_cli"
 
 [[bin]]
 name = "httpgenerator"

--- a/src/rust/httpgenerator-cli/README.md
+++ b/src/rust/httpgenerator-cli/README.md
@@ -1,0 +1,19 @@
+# httpgenerator
+
+`httpgenerator` is the Rust CLI for generating `.http` files from OpenAPI specifications.
+
+- Docs: https://docs.rs/httpgenerator
+- Homepage: https://christianhelle.github.io/httpgenerator/
+- Repository: https://github.com/christianhelle/httpgenerator
+
+## Install
+
+```bash
+cargo install httpgenerator
+```
+
+## Usage
+
+```bash
+httpgenerator ./openapi.json --output ./generated --no-logging
+```

--- a/src/rust/httpgenerator-compat/Cargo.toml
+++ b/src/rust/httpgenerator-compat/Cargo.toml
@@ -1,9 +1,14 @@
 [package]
 name = "httpgenerator-compat"
+authors.workspace = true
 version.workspace = true
 edition.workspace = true
+description = "Internal compatibility harness for HTTP File Generator"
+homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
+publish = false
 
 [dependencies]
 httpgenerator-core.workspace = true

--- a/src/rust/httpgenerator-compat/src/runner.rs
+++ b/src/rust/httpgenerator-compat/src/runner.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::CompatibilityScenario;
 
-const DEFAULT_RUST_CLI_PACKAGE: &str = "httpgenerator-cli";
+const DEFAULT_RUST_CLI_PACKAGE: &str = "httpgenerator";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommandSpec {
@@ -693,7 +693,7 @@ mod tests {
         assert_eq!(command.working_directory, repo_root);
         assert_eq!(command.args[0], "run");
         assert_eq!(command.args[1], "-p");
-        assert_eq!(command.args[2], "httpgenerator-cli");
+        assert_eq!(command.args[2], "httpgenerator");
         assert_eq!(command.args[3], "--");
         assert_eq!(command.args[4], plan.scenario.input_path.to_string_lossy());
         assert!(

--- a/src/rust/httpgenerator-core/Cargo.toml
+++ b/src/rust/httpgenerator-core/Cargo.toml
@@ -1,9 +1,17 @@
 [package]
 name = "httpgenerator-core"
+authors.workspace = true
 version.workspace = true
 edition.workspace = true
+description = "Core normalization and .http rendering for HTTP File Generator"
+homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
+documentation = "https://docs.rs/httpgenerator-core"
+readme = "README.md"
+keywords = ["openapi", "http", "generator", "codegen", "rest"]
+categories = ["development-tools", "web-programming"]
 
 [dependencies]
 base64 = "0.22.1"

--- a/src/rust/httpgenerator-core/README.md
+++ b/src/rust/httpgenerator-core/README.md
@@ -1,0 +1,19 @@
+# httpgenerator-core
+
+`httpgenerator-core` provides the normalized model and `.http` rendering primitives used by HTTP File Generator.
+
+- Docs: https://docs.rs/httpgenerator-core
+- Homepage: https://christianhelle.github.io/httpgenerator/
+- Repository: https://github.com/christianhelle/httpgenerator
+
+## Add to your project
+
+```bash
+cargo add httpgenerator-core
+```
+
+## API surface
+
+- normalize OpenAPI-derived models into generator-friendly types
+- generate `.http` files with `generate_http_files`
+- reuse filename, privacy, and support-information helpers

--- a/src/rust/httpgenerator-openapi/Cargo.toml
+++ b/src/rust/httpgenerator-openapi/Cargo.toml
@@ -1,9 +1,17 @@
 [package]
 name = "httpgenerator-openapi"
+authors.workspace = true
 version.workspace = true
 edition.workspace = true
+description = "OpenAPI loading, inspection, and normalization for HTTP File Generator"
+homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
+documentation = "https://docs.rs/httpgenerator-openapi"
+readme = "README.md"
+keywords = ["openapi", "http", "parser", "generator", "rest"]
+categories = ["development-tools", "parser-implementations", "web-programming"]
 
 [dependencies]
 httpgenerator-core.workspace = true

--- a/src/rust/httpgenerator-openapi/README.md
+++ b/src/rust/httpgenerator-openapi/README.md
@@ -1,0 +1,19 @@
+# httpgenerator-openapi
+
+`httpgenerator-openapi` loads, inspects, and normalizes OpenAPI documents for HTTP File Generator.
+
+- Docs: https://docs.rs/httpgenerator-openapi
+- Homepage: https://christianhelle.github.io/httpgenerator/
+- Repository: https://github.com/christianhelle/httpgenerator
+
+## Add to your project
+
+```bash
+cargo add httpgenerator-openapi
+```
+
+## API surface
+
+- load raw OpenAPI content from files, URLs, or in-memory sources
+- detect content format and specification version
+- inspect and normalize OpenAPI 3.0 and 3.1 documents

--- a/test/smoke-tests.ps1
+++ b/test/smoke-tests.ps1
@@ -38,8 +38,8 @@ function PrepareLocalRustCli {
         New-Item -ItemType Directory -Path $binDirectory | Out-Null
     }
 
-    Write-Host "cargo build --release -p httpgenerator-cli"
-    $process = Start-Process "cargo" -Args "build --release -p httpgenerator-cli" -NoNewWindow -PassThru
+    Write-Host "cargo build --release -p httpgenerator"
+    $process = Start-Process "cargo" -Args "build --release -p httpgenerator" -NoNewWindow -PassThru
     $process | Wait-Process
     if ($process.ExitCode -ne 0) {
         throw "cargo build failed"
@@ -475,5 +475,11 @@ function RunTests {
     }
 }
 
-Measure-Command { RunTests -Method "RustCli" -Parallel $Parallel -Production $Production }
-Write-Host "`r`n"
+Push-Location $PSScriptRoot
+try {
+    Measure-Command { RunTests -Method "RustCli" -Parallel $Parallel -Production $Production }
+    Write-Host "`r`n"
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
- **chore: squad session log**
- **feat(rust): prepare crates for crates.io**
- **test(smoke): anchor paths to script root**
- **ci(release): add crates.io publish flow**
- **docs: add crates.io install guidance**
- **Target Rust v1.95**
- **Fix task names in workflow**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added crates.io publishing support with gated, validated releases and tooling to ensure crate visibility.
  * Introduced three public Rust crates for distribution: httpgenerator, httpgenerator-core, and httpgenerator-openapi.

* **Documentation**
  * Updated installation and release guidance to treat crates.io as a first-class distribution channel.
  * Added crate-level READMEs and clarified public vs. private crate visibility.

* **Chores**
  * Renamed CLI package to httpgenerator and aligned workspace package metadata and dependency wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->