### PR TITLE
Improve httpgenerator-core rustdoc

### DIFF
--- a/src/rust/core/src/base_url.rs
+++ b/src/rust/core/src/base_url.rs
@@ -1,5 +1,29 @@
 use url::Url;
 
+/// Resolves the base URL used for generated request files.
+///
+/// Resolution follows the compatibility rules used by the CLI:
+///
+/// - `configured_base_url` takes precedence when supplied.
+/// - A relative `server_url` is appended to the configured base URL.
+/// - Without a configured base URL, the OpenAPI server URL is used.
+/// - Relative server URLs from remote OpenAPI documents inherit the document's
+///   URL authority.
+/// - Template-style configured values such as `{{MY_BASE_URL}}` are preserved.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::resolve_base_url;
+///
+/// let base_url = resolve_base_url(
+///     "https://petstore.swagger.io/v2/swagger.json",
+///     Some("/api/v3"),
+///     None,
+/// );
+///
+/// assert_eq!(base_url, "https://petstore.swagger.io/api/v3");
+/// ```
 pub fn resolve_base_url(
     open_api_path: &str,
     server_url: Option<&str>,

--- a/src/rust/core/src/file_naming.rs
+++ b/src/rust/core/src/file_naming.rs
@@ -1,5 +1,21 @@
 use std::{collections::HashSet, path::Path};
 
+/// Returns a case-insensitively unique filename and records it as used.
+///
+/// The first occurrence is returned unchanged. Subsequent duplicates receive a
+/// numeric suffix before the extension, starting at `_2`.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::unique_filename;
+/// use std::collections::HashSet;
+///
+/// let mut seen = HashSet::new();
+///
+/// assert_eq!(unique_filename("DeletePet.http", &mut seen), "DeletePet.http");
+/// assert_eq!(unique_filename("deletepet.http", &mut seen), "deletepet_2.http");
+/// ```
 pub fn unique_filename(filename: &str, seen: &mut HashSet<String>) -> String {
     if seen.insert(filename.to_ascii_lowercase()) {
         return filename.to_string();

--- a/src/rust/core/src/generator/mod.rs
+++ b/src/rust/core/src/generator/mod.rs
@@ -1,3 +1,11 @@
+//! `.http` renderer for normalized OpenAPI documents.
+//!
+//! The generator accepts a [`NormalizedOpenApiDocument`](crate::NormalizedOpenApiDocument)
+//! and [`GeneratorSettings`](crate::GeneratorSettings), then returns an in-memory
+//! [`GeneratorResult`](crate::GeneratorResult). Host applications decide whether
+//! to write the files to disk, show them in an editor, or package them for
+//! another workflow.
+
 mod modes;
 mod render;
 mod sample;

--- a/src/rust/core/src/generator/modes.rs
+++ b/src/rust/core/src/generator/modes.rs
@@ -10,6 +10,56 @@ use super::{
     text::{push_blank_line, push_line},
 };
 
+/// Renders `.http` files for every operation in a normalized OpenAPI document.
+///
+/// The shape of the returned file list is controlled by
+/// [`GeneratorSettings::output_type`]:
+///
+/// - [`OutputType::OneRequestPerFile`] creates one `.http` file per operation.
+/// - [`OutputType::OneFile`] creates a single `Requests.http` file.
+/// - [`OutputType::OneFilePerTag`] groups operations by their first tag.
+///
+/// File content is generated in memory. The function does not create
+/// directories, write to disk, or validate the original OpenAPI source.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::{
+///     generate_http_files, GeneratorSettings, NormalizedHttpMethod,
+///     NormalizedOpenApiDocument, NormalizedOperation, NormalizedServer,
+///     NormalizedSpecificationVersion, OutputType,
+/// };
+///
+/// let document = NormalizedOpenApiDocument {
+///     specification_version: NormalizedSpecificationVersion::OpenApi30,
+///     servers: vec![NormalizedServer {
+///         url: "https://api.example.com".to_string(),
+///     }],
+///     operations: vec![NormalizedOperation {
+///         path: "/pets".to_string(),
+///         method: NormalizedHttpMethod::Get,
+///         operation_id: Some("listPets".to_string()),
+///         summary: None,
+///         description: None,
+///         tags: vec!["Pets".to_string()],
+///         parameters: Vec::new(),
+///         request_body: None,
+///     }],
+/// };
+///
+/// let settings = GeneratorSettings {
+///     open_api_path: "openapi.json".to_string(),
+///     output_type: OutputType::OneFile,
+///     ..GeneratorSettings::default()
+/// };
+///
+/// let result = generate_http_files(&settings, &document);
+///
+/// assert_eq!(result.files.len(), 1);
+/// assert_eq!(result.files[0].filename, "Requests.http");
+/// assert!(result.files[0].content.contains("GET {{baseUrl}}/pets"));
+/// ```
 pub fn generate_http_files(
     settings: &GeneratorSettings,
     document: &NormalizedOpenApiDocument,

--- a/src/rust/core/src/lib.rs
+++ b/src/rust/core/src/lib.rs
@@ -1,13 +1,86 @@
+//! Core generation, normalization, and OpenAPI support for HTTP File Generator.
+//!
+//! `httpgenerator-core` contains the reusable library pieces behind the
+//! `httpgenerator` command-line tool:
+//!
+//! - [`generate_http_files`] renders normalized operations into `.http` files.
+//! - [`GeneratorSettings`] controls output layout, headers, and request
+//!   placeholders.
+//! - [`normalized`] contains the generator-friendly OpenAPI model accepted by
+//!   the renderer.
+//! - [`openapi`] loads, inspects, parses, and normalizes OpenAPI documents when
+//!   the default `openapi` feature is enabled.
+//!
+//! Most applications start with [`openapi::load_and_normalize_document`] and
+//! pass the resulting [`NormalizedOpenApiDocument`] to [`generate_http_files`].
+//! Consumers that already have their own OpenAPI parser can build the
+//! normalized model directly.
+//!
+//! # Example
+//!
+//! ```
+//! use httpgenerator_core::{
+//!     generate_http_files, GeneratorSettings, NormalizedHttpMethod,
+//!     NormalizedOpenApiDocument, NormalizedOperation, NormalizedServer,
+//!     NormalizedSpecificationVersion,
+//! };
+//!
+//! let document = NormalizedOpenApiDocument {
+//!     specification_version: NormalizedSpecificationVersion::OpenApi30,
+//!     servers: vec![NormalizedServer {
+//!         url: "https://api.example.com".to_string(),
+//!     }],
+//!     operations: vec![NormalizedOperation {
+//!         path: "/pets".to_string(),
+//!         method: NormalizedHttpMethod::Get,
+//!         operation_id: Some("listPets".to_string()),
+//!         summary: Some("List pets".to_string()),
+//!         description: None,
+//!         tags: vec!["Pets".to_string()],
+//!         parameters: Vec::new(),
+//!         request_body: None,
+//!     }],
+//! };
+//!
+//! let settings = GeneratorSettings {
+//!     open_api_path: "openapi.json".to_string(),
+//!     ..GeneratorSettings::default()
+//! };
+//!
+//! let result = generate_http_files(&settings, &document);
+//!
+//! assert_eq!(result.files[0].filename, "GetListPets.http");
+//! assert!(result.files[0].content.contains("GET {{baseUrl}}/pets"));
+//! ```
+//!
+//! # Feature flags
+//!
+//! The `openapi` feature is enabled by default and exposes the
+//! [`openapi`] module. Disabling default features keeps the renderer,
+//! normalized model, and helper APIs available without OpenAPI parser or HTTP
+//! client dependencies.
+#![warn(missing_docs)]
+
+/// Base URL resolution helpers used when rendering request files.
 pub mod base_url;
+/// Filename helpers for collision-safe `.http` outputs.
 pub mod file_naming;
+/// `.http` file rendering from normalized OpenAPI documents.
 pub mod generator;
+/// Input settings and output model types for generation.
 pub mod model;
+/// OpenAPI shapes normalized into a renderer-friendly model.
 pub mod normalized;
 #[cfg(feature = "openapi")]
+/// OpenAPI loading, parsing, inspection, and normalization.
 pub mod openapi;
+/// Operation name generation helpers.
 pub mod operation_name;
+/// Privacy helpers for redacting sensitive command-line values.
 pub mod privacy;
+/// String conversion helpers used by compatibility naming rules.
 pub mod string_extensions;
+/// Anonymous support identifier helpers.
 pub mod support_information;
 
 pub use base_url::resolve_base_url;

--- a/src/rust/core/src/model/mod.rs
+++ b/src/rust/core/src/model/mod.rs
@@ -1,3 +1,9 @@
+//! Generation settings and in-memory output types.
+//!
+//! These types are independent of OpenAPI parsing. They describe how normalized
+//! operations should be rendered and how generated `.http` files are returned to
+//! callers.
+
 mod output_type;
 mod result;
 mod settings;

--- a/src/rust/core/src/model/output_type.rs
+++ b/src/rust/core/src/model/output_type.rs
@@ -1,9 +1,18 @@
 use serde::{Deserialize, Serialize};
 
+/// Controls how rendered HTTP requests are grouped into output files.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum OutputType {
+    /// Generate one `.http` file for each operation.
+    ///
+    /// Filenames are derived from operation names and are made unique
+    /// case-insensitively.
     #[default]
     OneRequestPerFile,
+    /// Generate a single `Requests.http` file containing every operation.
     OneFile,
+    /// Generate one `.http` file for each operation tag.
+    ///
+    /// Operations without tags are grouped into `Default.http`.
     OneFilePerTag,
 }

--- a/src/rust/core/src/model/result.rs
+++ b/src/rust/core/src/model/result.rs
@@ -1,12 +1,30 @@
 use serde::{Deserialize, Serialize};
 
+/// A generated `.http` file held in memory.
+///
+/// Host applications can write this file to disk, display it directly, or
+/// transform it before presenting it to users.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HttpFile {
+    /// Suggested file name, including the `.http` extension.
     pub filename: String,
+    /// Complete file content.
     pub content: String,
 }
 
 impl HttpFile {
+    /// Creates a generated file from a filename and content.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use httpgenerator_core::HttpFile;
+    ///
+    /// let file = HttpFile::new("Requests.http", "GET https://example.com");
+    ///
+    /// assert_eq!(file.filename, "Requests.http");
+    /// assert_eq!(file.content, "GET https://example.com");
+    /// ```
     pub fn new(filename: impl Into<String>, content: impl Into<String>) -> Self {
         Self {
             filename: filename.into(),
@@ -15,12 +33,25 @@ impl HttpFile {
     }
 }
 
+/// The complete output of a generation run.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct GeneratorResult {
+    /// Generated files in the order they should be written or displayed.
     pub files: Vec<HttpFile>,
 }
 
 impl GeneratorResult {
+    /// Creates a generation result from generated files.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use httpgenerator_core::{GeneratorResult, HttpFile};
+    ///
+    /// let result = GeneratorResult::new(vec![HttpFile::new("Requests.http", "")]);
+    ///
+    /// assert_eq!(result.files.len(), 1);
+    /// ```
     pub fn new(files: Vec<HttpFile>) -> Self {
         Self { files }
     }

--- a/src/rust/core/src/model/settings.rs
+++ b/src/rust/core/src/model/settings.rs
@@ -2,22 +2,67 @@ use serde::{Deserialize, Serialize};
 
 use super::OutputType;
 
+/// Options that control `.http` rendering.
+///
+/// `GeneratorSettings` is intentionally serializable so host applications can
+/// move settings between CLI, editor, and test surfaces without translating
+/// fields. Defaults match the command-line tool's standard behavior.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::{GeneratorSettings, OutputType};
+///
+/// let settings = GeneratorSettings {
+///     open_api_path: "openapi.json".to_string(),
+///     output_type: OutputType::OneFile,
+///     base_url: Some("https://api.example.com".to_string()),
+///     ..GeneratorSettings::default()
+/// };
+///
+/// assert_eq!(settings.content_type, "application/json");
+/// assert_eq!(settings.timeout, 120);
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GeneratorSettings {
+    /// Original OpenAPI input path or URL.
+    ///
+    /// This is used for relative server URL resolution and for downstream hosts
+    /// that need to report the source being generated.
     pub open_api_path: String,
+    /// Optional authorization header value to emit into generated files.
+    ///
+    /// When [`authorization_header_from_environment_variable`](Self::authorization_header_from_environment_variable)
+    /// is `true`, this value is not written as a literal header variable.
     pub authorization_header: Option<String>,
+    /// Indicates whether the authorization value should be read by the HTTP
+    /// client from an environment variable rather than emitted literally.
     pub authorization_header_from_environment_variable: bool,
+    /// Variable name used for authorization placeholders in generated requests.
     pub authorization_header_variable_name: String,
+    /// Default content type used for request bodies.
     pub content_type: String,
+    /// Optional base URL override.
+    ///
+    /// If this is `None`, the first normalized server URL is used. If this is a
+    /// templated value such as `{{MY_BASE_URL}}`, relative server paths are
+    /// appended but the template itself is preserved.
     pub base_url: Option<String>,
+    /// Output grouping mode.
     pub output_type: OutputType,
+    /// Timeout value, in seconds, carried through for host compatibility.
     pub timeout: u64,
+    /// Indicates whether IntelliJ HTTP Client test snippets should be emitted.
     pub generate_intellij_tests: bool,
+    /// Additional raw header lines to include in generated requests.
     pub custom_headers: Vec<String>,
+    /// Skips generated file-level variables such as `@baseUrl` and
+    /// `@contentType`.
     pub skip_headers: bool,
 }
 
 impl Default for GeneratorSettings {
+    /// Creates settings that match the default CLI behavior.
     fn default() -> Self {
         Self {
             open_api_path: String::new(),

--- a/src/rust/core/src/normalized/document.rs
+++ b/src/rust/core/src/normalized/document.rs
@@ -2,33 +2,60 @@ use serde::{Deserialize, Serialize};
 
 use super::{NormalizedHttpMethod, NormalizedParameter, NormalizedRequestBody};
 
+/// OpenAPI specification version represented by a normalized document.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NormalizedSpecificationVersion {
+    /// Swagger/OpenAPI 2.0.
     Swagger2,
+    /// OpenAPI 3.0.x.
     OpenApi30,
+    /// OpenAPI 3.1.x.
     OpenApi31,
 }
 
+/// Version-neutral OpenAPI document used by the renderer.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NormalizedOpenApiDocument {
+    /// Detected source specification version.
     pub specification_version: NormalizedSpecificationVersion,
+    /// Server definitions used to resolve `@baseUrl`.
+    ///
+    /// The renderer currently uses the first server, if any.
     pub servers: Vec<NormalizedServer>,
+    /// Operations rendered into `.http` requests.
     pub operations: Vec<NormalizedOperation>,
 }
 
+/// A normalized server entry.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NormalizedServer {
+    /// Server URL exactly as normalized from the source document.
+    ///
+    /// Values may be absolute URLs, relative paths, or template placeholders.
     pub url: String,
 }
 
+/// A normalized HTTP operation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NormalizedOperation {
+    /// OpenAPI path template, such as `/pets/{petId}`.
     pub path: String,
+    /// HTTP method for the operation.
     pub method: NormalizedHttpMethod,
+    /// Optional OpenAPI `operationId`.
+    ///
+    /// When absent, the renderer derives a name from the method and path.
     pub operation_id: Option<String>,
+    /// Optional short summary rendered as request metadata.
     pub summary: Option<String>,
+    /// Optional long description rendered as request metadata.
     pub description: Option<String>,
+    /// Tags associated with the operation.
+    ///
+    /// [`crate::OutputType::OneFilePerTag`] uses the first tag for grouping.
     pub tags: Vec<String>,
+    /// Parameters declared directly on or inherited by the operation.
     pub parameters: Vec<NormalizedParameter>,
+    /// Optional request body definition.
     pub request_body: Option<NormalizedRequestBody>,
 }

--- a/src/rust/core/src/normalized/http.rs
+++ b/src/rust/core/src/normalized/http.rs
@@ -1,18 +1,36 @@
 use serde::{Deserialize, Serialize};
 
+/// HTTP methods supported by the normalized renderer model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NormalizedHttpMethod {
+    /// `GET`.
     Get,
+    /// `PUT`.
     Put,
+    /// `POST`.
     Post,
+    /// `DELETE`.
     Delete,
+    /// `OPTIONS`.
     Options,
+    /// `HEAD`.
     Head,
+    /// `PATCH`.
     Patch,
+    /// `TRACE`.
     Trace,
 }
 
 impl NormalizedHttpMethod {
+    /// Returns the lowercase HTTP method token used in generated `.http` files.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use httpgenerator_core::NormalizedHttpMethod;
+    ///
+    /// assert_eq!(NormalizedHttpMethod::Patch.as_str(), "patch");
+    /// ```
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Get => "get",
@@ -27,10 +45,15 @@ impl NormalizedHttpMethod {
     }
 }
 
+/// Location of an OpenAPI parameter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NormalizedParameterLocation {
+    /// Path parameter, usually replacing `{name}` in the path template.
     Path,
+    /// Query-string parameter.
     Query,
+    /// Header parameter.
     Header,
+    /// Cookie parameter.
     Cookie,
 }

--- a/src/rust/core/src/normalized/mod.rs
+++ b/src/rust/core/src/normalized/mod.rs
@@ -1,3 +1,13 @@
+//! Renderer-friendly OpenAPI model.
+//!
+//! The normalized model keeps only the information the `.http` renderer needs
+//! and presents it in a version-neutral shape. OpenAPI 2.0, 3.0, and 3.1
+//! documents can all be converted into these types before generation.
+//!
+//! You can build this model directly when integrating with another parser, or
+//! obtain it from [`crate::openapi::load_and_normalize_document`] when the
+//! `openapi` feature is enabled.
+
 mod document;
 mod http;
 mod parameter;

--- a/src/rust/core/src/normalized/parameter.rs
+++ b/src/rust/core/src/normalized/parameter.rs
@@ -2,17 +2,26 @@ use serde::{Deserialize, Serialize};
 
 use super::{NormalizedParameterLocation, NormalizedSchema};
 
+/// Normalized operation parameter.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NormalizedParameter {
+    /// Parameter details are available inline.
     Inline(NormalizedInlineParameter),
+    /// Parameter was represented by an unresolved OpenAPI `$ref`.
     Reference { reference: String },
 }
 
+/// Inline parameter details used by request rendering.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NormalizedInlineParameter {
+    /// Parameter name.
     pub name: String,
+    /// Location where the parameter is applied.
     pub location: NormalizedParameterLocation,
+    /// Optional parameter description.
     pub description: Option<String>,
+    /// Indicates whether callers must provide the parameter.
     pub required: bool,
+    /// Optional parameter schema.
     pub schema: Option<NormalizedSchema>,
 }

--- a/src/rust/core/src/normalized/parameter.rs
+++ b/src/rust/core/src/normalized/parameter.rs
@@ -8,7 +8,10 @@ pub enum NormalizedParameter {
     /// Parameter details are available inline.
     Inline(NormalizedInlineParameter),
     /// Parameter was represented by an unresolved OpenAPI `$ref`.
-    Reference { reference: String },
+    Reference {
+        /// Reference value, such as `#/components/parameters/PetId`.
+        reference: String,
+    },
 }
 
 /// Inline parameter details used by request rendering.

--- a/src/rust/core/src/normalized/request_body.rs
+++ b/src/rust/core/src/normalized/request_body.rs
@@ -8,7 +8,10 @@ pub enum NormalizedRequestBody {
     /// Request body details are available inline.
     Inline(NormalizedInlineRequestBody),
     /// Request body was represented by an unresolved OpenAPI `$ref`.
-    Reference { reference: String },
+    Reference {
+        /// Reference value, such as `#/components/requestBodies/Pet`.
+        reference: String,
+    },
 }
 
 /// Inline request body details.

--- a/src/rust/core/src/normalized/request_body.rs
+++ b/src/rust/core/src/normalized/request_body.rs
@@ -2,21 +2,31 @@ use serde::{Deserialize, Serialize};
 
 use super::NormalizedSchema;
 
+/// Normalized request body definition.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NormalizedRequestBody {
+    /// Request body details are available inline.
     Inline(NormalizedInlineRequestBody),
+    /// Request body was represented by an unresolved OpenAPI `$ref`.
     Reference { reference: String },
 }
 
+/// Inline request body details.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NormalizedInlineRequestBody {
+    /// Optional request body description.
     pub description: Option<String>,
+    /// Indicates whether callers must provide a body.
     pub required: bool,
+    /// Media types accepted by the operation.
     pub content: Vec<NormalizedMediaType>,
 }
 
+/// Media type entry for a request body.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NormalizedMediaType {
+    /// MIME content type, such as `application/json`.
     pub content_type: String,
+    /// Optional body schema for this media type.
     pub schema: Option<NormalizedSchema>,
 }

--- a/src/rust/core/src/normalized/schema.rs
+++ b/src/rust/core/src/normalized/schema.rs
@@ -1,30 +1,50 @@
 use serde::{Deserialize, Serialize};
 
+/// Normalized schema information used for request samples and placeholders.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct NormalizedSchema {
+    /// Optional unresolved OpenAPI `$ref`.
     pub reference: Option<String>,
+    /// Primitive or composite schema types.
     pub types: Vec<NormalizedSchemaType>,
+    /// Object properties.
     pub properties: Vec<NormalizedSchemaProperty>,
+    /// Array item schema.
     pub items: Option<Box<NormalizedSchema>>,
+    /// Schemas combined with `allOf`.
     pub all_of: Vec<NormalizedSchema>,
+    /// Schemas combined with `oneOf`.
     pub one_of: Vec<NormalizedSchema>,
+    /// Schemas combined with `anyOf`.
     pub any_of: Vec<NormalizedSchema>,
 }
 
+/// Named property in a normalized object schema.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NormalizedSchemaProperty {
+    /// Property name.
     pub name: String,
+    /// Property schema.
     pub schema: NormalizedSchema,
 }
 
+/// Schema type keywords recognized by the normalized model.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NormalizedSchemaType {
+    /// JSON string value.
     String,
+    /// JSON integer value.
     Integer,
+    /// JSON number value.
     Number,
+    /// JSON boolean value.
     Boolean,
+    /// JSON object value.
     Object,
+    /// JSON array value.
     Array,
+    /// JSON null value.
     Null,
+    /// Schema type not represented by a built-in variant.
     Other(String),
 }

--- a/src/rust/core/src/openapi/error.rs
+++ b/src/rust/core/src/openapi/error.rs
@@ -7,11 +7,20 @@ use crate::NormalizedHttpMethod;
 
 use super::{OpenApiContentFormat, OpenApiSource, OpenApiSpecificationVersion};
 
+/// Error returned when source input cannot be classified as a supported path or URL.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SourceClassificationError {
+    /// The supplied source string is empty or whitespace.
     EmptyInput,
+    /// The source looked like a URL but used an unsupported scheme.
     UnsupportedUrlScheme(String),
-    InvalidUrl { value: String, reason: String },
+    /// The source looked like an HTTP(S) URL but could not be parsed.
+    InvalidUrl {
+        /// Original source value.
+        value: String,
+        /// Parser error text.
+        reason: String,
+    },
 }
 
 impl fmt::Display for SourceClassificationError {
@@ -30,9 +39,12 @@ impl fmt::Display for SourceClassificationError {
 
 impl Error for SourceClassificationError {}
 
+/// Error returned when JSON/YAML content format cannot be detected.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContentFormatDetectionError {
+    /// The content is empty after trimming whitespace and a UTF-8 byte-order mark.
     EmptyContent,
+    /// The content does not look like JSON or YAML.
     UnknownFormat,
 }
 
@@ -47,32 +59,53 @@ impl fmt::Display for ContentFormatDetectionError {
 
 impl Error for ContentFormatDetectionError {}
 
+/// Error returned while loading a raw OpenAPI document.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RawOpenApiLoadError {
+    /// The input path or URL could not be classified.
     SourceClassification(SourceClassificationError),
+    /// A local file could not be read.
     FileRead {
+        /// File path that failed.
         path: PathBuf,
+        /// I/O error text.
         reason: String,
     },
+    /// A remote HTTP request could not be completed.
     HttpRequest {
+        /// Requested URL.
         url: Url,
+        /// Request error text.
         reason: String,
     },
+    /// A remote HTTP request completed with a non-success status.
     HttpStatus {
+        /// Requested URL.
         url: Url,
+        /// Returned HTTP status code.
         status: StatusCode,
     },
+    /// The response body could not be read or converted to UTF-8.
     HttpBodyRead {
+        /// Requested URL.
         url: Url,
+        /// Body read or decoding error text.
         reason: String,
     },
+    /// JSON/YAML format detection failed.
     FormatDetection {
+        /// Source being decoded.
         source: OpenApiSource,
+        /// Format detection failure.
         error: ContentFormatDetectionError,
     },
+    /// JSON or YAML content could not be decoded.
     Decode {
+        /// Source being decoded.
         source: OpenApiSource,
+        /// Format selected for decoding.
         format: OpenApiContentFormat,
+        /// Decoder error text.
         reason: String,
     },
 }
@@ -124,11 +157,23 @@ impl fmt::Display for RawOpenApiLoadError {
 
 impl Error for RawOpenApiLoadError {}
 
+/// Error returned when an OpenAPI specification version cannot be detected.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SpecificationVersionDetectionError {
+    /// The document has no top-level `openapi` or `swagger` field.
     MissingVersionField,
-    InvalidVersionFieldType { field: &'static str },
-    UnsupportedVersion { field: &'static str, value: String },
+    /// The version field exists but is not a non-empty string.
+    InvalidVersionFieldType {
+        /// Name of the invalid version field.
+        field: &'static str,
+    },
+    /// The version field contains a version family this crate does not support.
+    UnsupportedVersion {
+        /// Name of the version field.
+        field: &'static str,
+        /// Unsupported version value.
+        value: String,
+    },
 }
 
 impl fmt::Display for SpecificationVersionDetectionError {
@@ -155,9 +200,12 @@ impl fmt::Display for SpecificationVersionDetectionError {
 
 impl Error for SpecificationVersionDetectionError {}
 
+/// Error returned while inspecting an OpenAPI document.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OpenApiInspectionError {
+    /// Raw document loading failed.
     Load(RawOpenApiLoadError),
+    /// Version detection failed.
     VersionDetection(SpecificationVersionDetectionError),
 }
 
@@ -172,19 +220,30 @@ impl fmt::Display for OpenApiInspectionError {
 
 impl Error for OpenApiInspectionError {}
 
+/// Error returned while parsing a raw document into a typed OpenAPI model.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypedOpenApiParseError {
+    /// The document's specification version could not be detected.
     VersionDetection {
+        /// Source being parsed.
         source: OpenApiSource,
+        /// Version detection failure.
         error: SpecificationVersionDetectionError,
     },
+    /// The detected version is not supported by the typed parser.
     UnsupportedVersion {
+        /// Source being parsed.
         source: OpenApiSource,
+        /// Detected unsupported version.
         version: OpenApiSpecificationVersion,
     },
+    /// Deserialization into the version-specific Rust model failed.
     Deserialize {
+        /// Source being parsed.
         source: OpenApiSource,
+        /// Version-specific model selected for parsing.
         version: OpenApiSpecificationVersion,
+        /// Deserialization error text.
         reason: String,
     },
 }
@@ -220,9 +279,12 @@ impl fmt::Display for TypedOpenApiParseError {
 
 impl Error for TypedOpenApiParseError {}
 
+/// Error returned while loading a typed or partially typed OpenAPI document.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OpenApiDocumentLoadError {
+    /// Raw document loading failed.
     RawLoad(RawOpenApiLoadError),
+    /// Typed parsing failed.
     TypedParse(TypedOpenApiParseError),
 }
 
@@ -237,24 +299,39 @@ impl fmt::Display for OpenApiDocumentLoadError {
 
 impl Error for OpenApiDocumentLoadError {}
 
+/// Error returned while converting a loaded OpenAPI document into the normalized model.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OpenApiNormalizationError {
+    /// The source document shape was not compatible with the normalizer.
     InvalidStructure {
+        /// JSON pointer-like path to the unexpected value.
         path: String,
+        /// Additional context about the expected structure.
         context: String,
     },
+    /// A path item `$ref` was encountered where inline path items are required.
     UnsupportedPathItemReference {
+        /// OpenAPI path containing the reference.
         path: String,
+        /// Referenced path item.
         reference: String,
     },
+    /// A parameter `$ref` was encountered where inline parameters are required.
     UnsupportedParameterReference {
+        /// OpenAPI path containing the parameter.
         path: String,
+        /// Operation method containing the parameter.
         method: NormalizedHttpMethod,
+        /// Referenced parameter.
         reference: String,
     },
+    /// A request body `$ref` was encountered where inline request bodies are required.
     UnsupportedRequestBodyReference {
+        /// OpenAPI path containing the request body.
         path: String,
+        /// Operation method containing the request body.
         method: NormalizedHttpMethod,
+        /// Referenced request body.
         reference: String,
     },
 }
@@ -300,9 +377,12 @@ impl fmt::Display for OpenApiNormalizationError {
 
 impl Error for OpenApiNormalizationError {}
 
+/// Error returned while loading and normalizing an OpenAPI document.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OpenApiDocumentNormalizationError {
+    /// Loading or typed parsing failed.
     Load(OpenApiDocumentLoadError),
+    /// Normalization failed after the document was loaded.
     Normalize(OpenApiNormalizationError),
 }
 

--- a/src/rust/core/src/openapi/format.rs
+++ b/src/rust/core/src/openapi/format.rs
@@ -2,13 +2,25 @@ use std::{fmt, path::Path};
 
 use super::{ContentFormatDetectionError, OpenApiSource};
 
+/// Detected textual representation of an OpenAPI document.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OpenApiContentFormat {
+    /// JSON document.
     Json,
+    /// YAML document.
     Yaml,
 }
 
 impl OpenApiContentFormat {
+    /// Returns a human-readable format name.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use httpgenerator_core::openapi::OpenApiContentFormat;
+    ///
+    /// assert_eq!(OpenApiContentFormat::Json.as_str(), "JSON");
+    /// ```
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Json => "JSON",
@@ -16,6 +28,22 @@ impl OpenApiContentFormat {
         }
     }
 
+    /// Infers the content format from a file path extension.
+    ///
+    /// `.json` maps to [`OpenApiContentFormat::Json`], while `.yaml` and
+    /// `.yml` map to [`OpenApiContentFormat::Yaml`]. Extension matching is
+    /// case-insensitive.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use httpgenerator_core::openapi::OpenApiContentFormat;
+    ///
+    /// assert_eq!(
+    ///     OpenApiContentFormat::from_path("openapi.YML"),
+    ///     Some(OpenApiContentFormat::Yaml)
+    /// );
+    /// ```
     pub fn from_path(path: impl AsRef<Path>) -> Option<Self> {
         let extension = path.as_ref().extension()?.to_str()?;
 
@@ -37,6 +65,11 @@ impl fmt::Display for OpenApiContentFormat {
     }
 }
 
+/// Detects an OpenAPI document's content format.
+///
+/// A known file extension from `source` is preferred. If the source has no
+/// format hint, the content is sniffed after trimming a UTF-8 byte-order mark
+/// and leading whitespace.
 pub fn detect_content_format(
     source: Option<&OpenApiSource>,
     content: &str,
@@ -52,6 +85,20 @@ pub fn detect_content_format(
     sniff_content_format(content)
 }
 
+/// Sniffs JSON or YAML from document content alone.
+///
+/// JSON is detected from leading `{` or `[`. YAML is detected from common YAML
+/// document markers, list items, or mapping syntax.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::openapi::{sniff_content_format, OpenApiContentFormat};
+///
+/// let format = sniff_content_format("openapi: 3.0.0\ninfo:\n  title: Example").unwrap();
+///
+/// assert_eq!(format, OpenApiContentFormat::Yaml);
+/// ```
 pub fn sniff_content_format(
     content: &str,
 ) -> Result<OpenApiContentFormat, ContentFormatDetectionError> {

--- a/src/rust/core/src/openapi/inspect/mod.rs
+++ b/src/rust/core/src/openapi/inspect/mod.rs
@@ -11,11 +11,28 @@ use super::{
 };
 pub use model::{OpenApiInspection, OpenApiStats};
 
+/// Loads and inspects an OpenAPI document from a path or URL.
+///
+/// Inspection does not normalize operations for generation. It collects a
+/// lightweight version and statistics summary useful for UI previews and
+/// validation messages.
+///
+/// # Example
+///
+/// ```no_run
+/// use httpgenerator_core::openapi::inspect_document;
+///
+/// let inspection = inspect_document("openapi.json")?;
+///
+/// println!("{} operations", inspection.stats.operation_count);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 pub fn inspect_document(input: &str) -> Result<OpenApiInspection, OpenApiInspectionError> {
     let raw = load_raw_document(input).map_err(OpenApiInspectionError::Load)?;
     inspect_raw_document(&raw)
 }
 
+/// Inspects an already decoded raw OpenAPI document.
 pub fn inspect_raw_document(
     document: &RawOpenApiDocument,
 ) -> Result<OpenApiInspection, OpenApiInspectionError> {

--- a/src/rust/core/src/openapi/inspect/model.rs
+++ b/src/rust/core/src/openapi/inspect/model.rs
@@ -1,19 +1,31 @@
 use super::super::OpenApiSpecificationVersion;
 
+/// Counts of notable structures in an OpenAPI document.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct OpenApiStats {
+    /// Number of parameters found in paths, operations, and components.
     pub parameter_count: usize,
+    /// Number of schemas found in components and inline request/response shapes.
     pub schema_count: usize,
+    /// Number of path items in the `paths` object.
     pub path_item_count: usize,
+    /// Number of request body definitions found inline or in components.
     pub request_body_count: usize,
+    /// Number of response definitions found inline or in components.
     pub response_count: usize,
+    /// Number of operations under paths.
     pub operation_count: usize,
+    /// Number of links found in responses or components.
     pub link_count: usize,
+    /// Number of callbacks found in operations or components.
     pub callback_count: usize,
 }
 
+/// Lightweight inspection result for an OpenAPI document.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OpenApiInspection {
+    /// Detected specification family.
     pub specification_version: OpenApiSpecificationVersion,
+    /// Collected document statistics.
     pub stats: OpenApiStats,
 }

--- a/src/rust/core/src/openapi/loader.rs
+++ b/src/rust/core/src/openapi/loader.rs
@@ -4,24 +4,38 @@ use super::{
     load_raw_document_from_source, parse_typed_document,
 };
 
+/// Loaded OpenAPI document with raw metadata and optional typed representation.
 pub enum LoadedOpenApiDocument {
+    /// Swagger 2.0 document retained as raw JSON/YAML for normalization.
     Swagger2 {
+        /// Raw decoded document.
         raw: RawOpenApiDocument,
     },
+    /// OpenAPI 3.0 document with a typed `openapiv3` representation.
     OpenApi30 {
+        /// Raw decoded document.
         raw: RawOpenApiDocument,
+        /// Typed OpenAPI 3.0 document.
         document: openapiv3::OpenAPI,
     },
+    /// OpenAPI 3.1 document with a typed `openapiv3_1` representation.
     OpenApi31 {
+        /// Raw decoded document.
         raw: RawOpenApiDocument,
+        /// Typed OpenAPI 3.1 document.
         document: openapiv3_1::OpenApi,
     },
+    /// OpenAPI 3.1 document kept raw when typed parsing is unavailable.
+    ///
+    /// This is used for webhook-only documents and for tolerant loading paths.
     OpenApi31Raw {
+        /// Raw decoded document.
         raw: RawOpenApiDocument,
     },
 }
 
 impl LoadedOpenApiDocument {
+    /// Returns the raw decoded document.
     pub fn raw(&self) -> &RawOpenApiDocument {
         match self {
             Self::Swagger2 { raw }
@@ -31,14 +45,17 @@ impl LoadedOpenApiDocument {
         }
     }
 
+    /// Returns the original classified source.
     pub fn source(&self) -> &OpenApiSource {
         self.raw().source()
     }
 
+    /// Returns the detected JSON/YAML content format.
     pub fn format(&self) -> OpenApiContentFormat {
         self.raw().format()
     }
 
+    /// Returns the detected specification family.
     pub fn specification_version(&self) -> OpenApiSpecificationVersion {
         match self {
             Self::Swagger2 { .. } => OpenApiSpecificationVersion::Swagger2,
@@ -49,6 +66,7 @@ impl LoadedOpenApiDocument {
         }
     }
 
+    /// Returns the typed OpenAPI 3.0 document when this is an OpenAPI 3.0 load.
     pub fn as_openapi30(&self) -> Option<&openapiv3::OpenAPI> {
         match self {
             Self::Swagger2 { .. } | Self::OpenApi31 { .. } | Self::OpenApi31Raw { .. } => None,
@@ -56,6 +74,9 @@ impl LoadedOpenApiDocument {
         }
     }
 
+    /// Returns the typed OpenAPI 3.1 document when typed parsing succeeded.
+    ///
+    /// This returns `None` for [`LoadedOpenApiDocument::OpenApi31Raw`].
     pub fn as_openapi31(&self) -> Option<&openapiv3_1::OpenApi> {
         match self {
             Self::Swagger2 { .. } | Self::OpenApi30 { .. } | Self::OpenApi31Raw { .. } => None,
@@ -64,6 +85,18 @@ impl LoadedOpenApiDocument {
     }
 }
 
+/// Loads a document from a path or URL and parses it as far as supported.
+///
+/// # Example
+///
+/// ```no_run
+/// use httpgenerator_core::openapi::load_document;
+///
+/// let document = load_document("https://example.com/openapi.json")?;
+///
+/// println!("Loaded {}", document.specification_version());
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 pub fn load_document(input: &str) -> Result<LoadedOpenApiDocument, OpenApiDocumentLoadError> {
     load_document_with_options(input, false)
 }
@@ -76,6 +109,7 @@ pub(crate) fn load_document_with_options(
     load_document_from_raw_with_options(raw, tolerate_invalid_openapi31)
 }
 
+/// Loads a document from an already classified source and parses it as far as supported.
 pub fn load_document_from_source(
     source: OpenApiSource,
 ) -> Result<LoadedOpenApiDocument, OpenApiDocumentLoadError> {
@@ -90,6 +124,7 @@ pub(crate) fn load_document_from_source_with_options(
     load_document_from_raw_with_options(raw, tolerate_invalid_openapi31)
 }
 
+/// Parses an already decoded raw document as far as supported.
 pub fn load_document_from_raw(
     raw: RawOpenApiDocument,
 ) -> Result<LoadedOpenApiDocument, OpenApiDocumentLoadError> {

--- a/src/rust/core/src/openapi/mod.rs
+++ b/src/rust/core/src/openapi/mod.rs
@@ -1,3 +1,18 @@
+//! OpenAPI source loading, parsing, inspection, and normalization.
+//!
+//! This module is available when the default `openapi` feature is enabled. It
+//! provides layered entry points:
+//!
+//! - [`classify_source`] distinguishes local paths from `http` and `https`
+//!   URLs.
+//! - [`load_raw_document`] reads and decodes JSON or YAML into a
+//!   [`RawOpenApiDocument`].
+//! - [`load_document`] additionally parses supported versions into typed
+//!   OpenAPI structures where available.
+//! - [`inspect_document`] collects lightweight statistics for UI or telemetry.
+//! - [`load_and_normalize_document`] converts an OpenAPI document into the
+//!   renderer-friendly [`crate::NormalizedOpenApiDocument`].
+
 mod error;
 mod format;
 mod inspect;

--- a/src/rust/core/src/openapi/mod.rs
+++ b/src/rust/core/src/openapi/mod.rs
@@ -3,15 +3,16 @@
 //! This module is available when the default `openapi` feature is enabled. It
 //! provides layered entry points:
 //!
-//! - [`classify_source`] distinguishes local paths from `http` and `https`
-//!   URLs.
-//! - [`load_raw_document`] reads and decodes JSON or YAML into a
-//!   [`RawOpenApiDocument`].
-//! - [`load_document`] additionally parses supported versions into typed
-//!   OpenAPI structures where available.
-//! - [`inspect_document`] collects lightweight statistics for UI or telemetry.
-//! - [`load_and_normalize_document`] converts an OpenAPI document into the
-//!   renderer-friendly [`crate::NormalizedOpenApiDocument`].
+//! - [`crate::openapi::classify_source`] distinguishes local paths from `http`
+//!   and `https` URLs.
+//! - [`crate::openapi::load_raw_document`] reads and decodes JSON or YAML into a
+//!   [`crate::openapi::RawOpenApiDocument`].
+//! - [`crate::openapi::load_document`] additionally parses supported versions
+//!   into typed OpenAPI structures where available.
+//! - [`crate::openapi::inspect_document`] collects lightweight statistics for UI
+//!   or telemetry.
+//! - [`crate::openapi::load_and_normalize_document`] converts an OpenAPI
+//!   document into the renderer-friendly [`crate::NormalizedOpenApiDocument`].
 
 mod error;
 mod format;

--- a/src/rust/core/src/openapi/normalize/mod.rs
+++ b/src/rust/core/src/openapi/normalize/mod.rs
@@ -15,12 +15,38 @@ use super::{
     OpenApiSpecificationVersion,
 };
 
+/// Loads an OpenAPI document and converts it into the normalized renderer model.
+///
+/// This is the highest-level OpenAPI entry point for callers that want to
+/// generate `.http` files from a path or URL.
+///
+/// # Example
+///
+/// ```no_run
+/// use httpgenerator_core::{generate_http_files, GeneratorSettings};
+/// use httpgenerator_core::openapi::load_and_normalize_document;
+///
+/// let input = "openapi.yaml";
+/// let document = load_and_normalize_document(input)?;
+/// let settings = GeneratorSettings {
+///     open_api_path: input.to_string(),
+///     ..GeneratorSettings::default()
+/// };
+/// let result = generate_http_files(&settings, &document);
+///
+/// println!("Generated {} file(s)", result.files.len());
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 pub fn load_and_normalize_document(
     input: &str,
 ) -> Result<NormalizedOpenApiDocument, OpenApiDocumentNormalizationError> {
     load_and_normalize_document_with_options(input, false)
 }
 
+/// Loads and normalizes an OpenAPI document with tolerant OpenAPI 3.1 handling.
+///
+/// When `tolerate_invalid_openapi31` is `true`, OpenAPI 3.1 documents that
+/// fail typed parsing can still be normalized from their raw JSON/YAML value.
 pub fn load_and_normalize_document_with_options(
     input: &str,
     tolerate_invalid_openapi31: bool,
@@ -30,6 +56,7 @@ pub fn load_and_normalize_document_with_options(
     normalize_loaded_document(&document).map_err(OpenApiDocumentNormalizationError::Normalize)
 }
 
+/// Normalizes an already loaded OpenAPI document.
 pub fn normalize_loaded_document(
     document: &LoadedOpenApiDocument,
 ) -> Result<NormalizedOpenApiDocument, OpenApiNormalizationError> {

--- a/src/rust/core/src/openapi/raw.rs
+++ b/src/rust/core/src/openapi/raw.rs
@@ -8,6 +8,12 @@ use super::{
     detect_specification_version,
 };
 
+/// Raw OpenAPI document decoded into generic JSON values.
+///
+/// `RawOpenApiDocument` preserves the original source, detected content format,
+/// raw text content, and decoded [`serde_json::Value`]. It is useful when a
+/// caller needs format/version information before choosing a typed parser or
+/// normalizer.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RawOpenApiDocument {
     source: OpenApiSource,
@@ -17,26 +23,32 @@ pub struct RawOpenApiDocument {
 }
 
 impl RawOpenApiDocument {
+    /// Returns the source this document was loaded from.
     pub fn source(&self) -> &OpenApiSource {
         &self.source
     }
 
+    /// Returns the detected JSON/YAML content format.
     pub fn format(&self) -> OpenApiContentFormat {
         self.format
     }
 
+    /// Returns the original document text.
     pub fn content(&self) -> &str {
         &self.content
     }
 
+    /// Returns the decoded document value.
     pub fn value(&self) -> &Value {
         &self.value
     }
 
+    /// Consumes the document and returns the decoded value.
     pub fn into_value(self) -> Value {
         self.value
     }
 
+    /// Detects the OpenAPI specification version for this raw document.
     pub fn specification_version(
         &self,
     ) -> Result<OpenApiSpecificationVersion, SpecificationVersionDetectionError> {
@@ -44,11 +56,24 @@ impl RawOpenApiDocument {
     }
 }
 
+/// Loads and decodes a raw OpenAPI document from a path or URL string.
+///
+/// # Example
+///
+/// ```no_run
+/// use httpgenerator_core::openapi::load_raw_document;
+///
+/// let document = load_raw_document("openapi.yaml")?;
+///
+/// println!("Loaded {} as {}", document.source(), document.format());
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 pub fn load_raw_document(input: &str) -> Result<RawOpenApiDocument, RawOpenApiLoadError> {
     let source = classify_source(input).map_err(RawOpenApiLoadError::SourceClassification)?;
     load_raw_document_from_source(source)
 }
 
+/// Loads and decodes a raw OpenAPI document from an already classified source.
 pub fn load_raw_document_from_source(
     source: OpenApiSource,
 ) -> Result<RawOpenApiDocument, RawOpenApiLoadError> {
@@ -56,6 +81,27 @@ pub fn load_raw_document_from_source(
     decode_raw_document(source, content)
 }
 
+/// Decodes raw document content from a known source.
+///
+/// This does not read from the filesystem or network. It detects the content
+/// format, decodes JSON or YAML into [`serde_json::Value`], and preserves the
+/// original text.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::openapi::{
+///     decode_raw_document, OpenApiContentFormat, OpenApiSource,
+/// };
+/// use std::path::PathBuf;
+///
+/// let document = decode_raw_document(
+///     OpenApiSource::Path(PathBuf::from("openapi.json")),
+///     r#"{"openapi":"3.0.0","info":{"title":"Example","version":"1.0.0"},"paths":{}}"#,
+/// ).unwrap();
+///
+/// assert_eq!(document.format(), OpenApiContentFormat::Json);
+/// ```
 pub fn decode_raw_document(
     source: OpenApiSource,
     content: impl Into<String>,

--- a/src/rust/core/src/openapi/source.rs
+++ b/src/rust/core/src/openapi/source.rs
@@ -7,21 +7,27 @@ use url::Url;
 
 use super::{OpenApiContentFormat, SourceClassificationError};
 
+/// OpenAPI document source.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OpenApiSource {
+    /// Local filesystem path.
     Path(PathBuf),
+    /// Remote `http` or `https` URL.
     Url(Url),
 }
 
 impl OpenApiSource {
+    /// Returns `true` when this source is a local path.
     pub fn is_local_path(&self) -> bool {
         matches!(self, Self::Path(_))
     }
 
+    /// Returns `true` when this source is an HTTP(S) URL.
     pub fn is_url(&self) -> bool {
         matches!(self, Self::Url(_))
     }
 
+    /// Returns the content format implied by the path or URL extension.
     pub fn format_hint(&self) -> Option<OpenApiContentFormat> {
         match self {
             Self::Path(path) => OpenApiContentFormat::from_path(path),
@@ -39,6 +45,22 @@ impl fmt::Display for OpenApiSource {
     }
 }
 
+/// Classifies user input as a local path or remote URL.
+///
+/// Only `http` and `https` URLs are accepted. Inputs with other URL-like
+/// schemes return [`SourceClassificationError::UnsupportedUrlScheme`]. Windows
+/// absolute paths such as `C:\specs\openapi.json` are treated as local paths,
+/// not URL schemes.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::openapi::{classify_source, OpenApiSource};
+///
+/// let source = classify_source("https://example.com/openapi.json").unwrap();
+///
+/// assert!(matches!(source, OpenApiSource::Url(_)));
+/// ```
 pub fn classify_source(input: &str) -> Result<OpenApiSource, SourceClassificationError> {
     let trimmed = input.trim();
 

--- a/src/rust/core/src/openapi/typed.rs
+++ b/src/rust/core/src/openapi/typed.rs
@@ -1,11 +1,15 @@
 use super::{OpenApiSpecificationVersion, RawOpenApiDocument, TypedOpenApiParseError};
 
+/// OpenAPI document parsed into a version-specific Rust model.
 pub enum TypedOpenApiDocument {
+    /// OpenAPI 3.0 document parsed by the `openapiv3` crate.
     OpenApi30(openapiv3::OpenAPI),
+    /// OpenAPI 3.1 document parsed by the `openapiv3_1` crate.
     OpenApi31(openapiv3_1::OpenApi),
 }
 
 impl TypedOpenApiDocument {
+    /// Returns the parsed document's specification family.
     pub fn specification_version(&self) -> OpenApiSpecificationVersion {
         match self {
             Self::OpenApi30(_) => OpenApiSpecificationVersion::OpenApi30,
@@ -14,6 +18,10 @@ impl TypedOpenApiDocument {
     }
 }
 
+/// Parses a raw document into its matching typed OpenAPI model.
+///
+/// Swagger 2.0 documents are detected but not parsed into a typed model by this
+/// API; use normalization when you need the compatibility bridge.
 pub fn parse_typed_document(
     document: &RawOpenApiDocument,
 ) -> Result<TypedOpenApiDocument, TypedOpenApiParseError> {
@@ -36,12 +44,14 @@ pub fn parse_typed_document(
     }
 }
 
+/// Parses a raw OpenAPI 3.0 document using the `openapiv3` model.
 pub fn parse_openapi30_document(
     document: &RawOpenApiDocument,
 ) -> Result<openapiv3::OpenAPI, TypedOpenApiParseError> {
     parse_versioned_document(document, OpenApiSpecificationVersion::OpenApi30)
 }
 
+/// Parses a raw OpenAPI 3.1 document using the `openapiv3_1` model.
 pub fn parse_openapi31_document(
     document: &RawOpenApiDocument,
 ) -> Result<openapiv3_1::OpenApi, TypedOpenApiParseError> {

--- a/src/rust/core/src/openapi/version.rs
+++ b/src/rust/core/src/openapi/version.rs
@@ -4,10 +4,14 @@ use serde_json::Value;
 
 use super::SpecificationVersionDetectionError;
 
+/// Supported OpenAPI specification families.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OpenApiSpecificationVersion {
+    /// Swagger/OpenAPI 2.0 document.
     Swagger2,
+    /// OpenAPI 3.0.x document.
     OpenApi30,
+    /// OpenAPI 3.1.x document.
     OpenApi31,
 }
 
@@ -21,6 +25,27 @@ impl fmt::Display for OpenApiSpecificationVersion {
     }
 }
 
+/// Detects a document's OpenAPI specification family from its top-level version.
+///
+/// The detector reads `openapi` for OpenAPI 3.x documents and `swagger` for
+/// Swagger 2.0 documents. Patch versions are accepted, but only the supported
+/// major/minor families are classified.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::openapi::{
+///     detect_specification_version, OpenApiSpecificationVersion,
+/// };
+/// use serde_json::json;
+///
+/// let value = json!({ "openapi": "3.1.0", "info": { "title": "Example" } });
+///
+/// assert_eq!(
+///     detect_specification_version(&value).unwrap(),
+///     OpenApiSpecificationVersion::OpenApi31
+/// );
+/// ```
 pub fn detect_specification_version(
     value: &Value,
 ) -> Result<OpenApiSpecificationVersion, SpecificationVersionDetectionError> {

--- a/src/rust/core/src/operation_name.rs
+++ b/src/rust/core/src/operation_name.rs
@@ -3,6 +3,27 @@ use crate::string_extensions::{
     convert_spaces_to_pascal_case, prefix,
 };
 
+/// Generates a stable request operation name for filenames and placeholders.
+///
+/// `operation_id` is preferred when present and non-empty. Otherwise, the name
+/// is derived from the HTTP method and path. The returned name is normalized
+/// using the compatibility casing rules and is prefixed with the HTTP method
+/// when it does not already start with that prefix.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::generate_operation_name;
+///
+/// assert_eq!(
+///     generate_operation_name("get", "/pet/find-by-status", Some("find-pets")),
+///     "GetFindPets"
+/// );
+/// assert_eq!(
+///     generate_operation_name("post", "/pet/store", None),
+///     "Post_PetStore"
+/// );
+/// ```
 pub fn generate_operation_name(
     http_method: &str,
     path: &str,

--- a/src/rust/core/src/privacy.rs
+++ b/src/rust/core/src/privacy.rs
@@ -10,6 +10,22 @@ const PATTERNS: &[&str] = &[
     r#"--authorization-header [^ ]+"#,
 ];
 
+/// Redacts `--authorization-header` command-line values from text.
+///
+/// This helper is intended for diagnostics, telemetry, and support output. It
+/// recognizes quoted and unquoted values, including common two-part schemes
+/// such as `Bearer <token>`, and replaces the sensitive value with
+/// `[REDACTED]`.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::redact_authorization_headers;
+///
+/// let redacted = redact_authorization_headers("--authorization-header Bearer secret");
+///
+/// assert_eq!(redacted, "--authorization-header [REDACTED]");
+/// ```
 pub fn redact_authorization_headers(input: &str) -> String {
     PATTERNS.iter().fold(input.to_string(), |current, pattern| {
         RegexBuilder::new(pattern)

--- a/src/rust/core/src/string_extensions.rs
+++ b/src/rust/core/src/string_extensions.rs
@@ -1,3 +1,17 @@
+/// Converts a kebab-case string to PascalCase using compatibility rules.
+///
+/// Empty segments are ignored and dots are replaced with underscores.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::convert_kebab_case_to_pascal_case;
+///
+/// assert_eq!(
+///     convert_kebab_case_to_pascal_case("find-pets.by-status"),
+///     "FindPets_byStatus"
+/// );
+/// ```
 pub fn convert_kebab_case_to_pascal_case(value: &str) -> String {
     value
         .split('-')
@@ -7,6 +21,18 @@ pub fn convert_kebab_case_to_pascal_case(value: &str) -> String {
         .join("")
 }
 
+/// Converts a route path into a camel-cased identifier fragment.
+///
+/// Leading and repeated slashes are ignored. The first path segment keeps its
+/// original casing, while subsequent segments are capitalized.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::convert_route_to_camel_case;
+///
+/// assert_eq!(convert_route_to_camel_case("/pet/findByStatus"), "petFindByStatus");
+/// ```
 pub fn convert_route_to_camel_case(value: &str) -> String {
     let mut parts = value
         .split('/')
@@ -21,6 +47,18 @@ pub fn convert_route_to_camel_case(value: &str) -> String {
     parts.join("")
 }
 
+/// Uppercases the first Unicode scalar value in a string.
+///
+/// Returns an empty string for empty input.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::capitalize_first_character;
+///
+/// assert_eq!(capitalize_first_character("pet"), "Pet");
+/// assert_eq!(capitalize_first_character(""), "");
+/// ```
 pub fn capitalize_first_character(value: &str) -> String {
     let mut chars = value.chars();
     let Some(first) = chars.next() else {
@@ -30,6 +68,15 @@ pub fn capitalize_first_character(value: &str) -> String {
     format!("{}{}", first.to_uppercase(), chars.as_str())
 }
 
+/// Converts space-separated words to PascalCase.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::convert_spaces_to_pascal_case;
+///
+/// assert_eq!(convert_spaces_to_pascal_case("list pets"), "ListPets");
+/// ```
 pub fn convert_spaces_to_pascal_case(value: &str) -> String {
     value
         .split(' ')
@@ -39,6 +86,16 @@ pub fn convert_spaces_to_pascal_case(value: &str) -> String {
         .join("")
 }
 
+/// Prefixes a value unless it already starts with that prefix.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::prefix;
+///
+/// assert_eq!(prefix("Pet", "Get"), "GetPet");
+/// assert_eq!(prefix("GetPet", "Get"), "GetPet");
+/// ```
 pub fn prefix(value: &str, prefix_value: &str) -> String {
     if value.starts_with(prefix_value) {
         return value.to_string();
@@ -47,6 +104,20 @@ pub fn prefix(value: &str, prefix_value: &str) -> String {
     format!("{prefix_value}{value}")
 }
 
+/// Prefixes every line break in a string with a marker and a space.
+///
+/// This preserves the platform newline style used by the renderer. `None`
+/// remains `None`.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::prefix_line_breaks;
+///
+/// let value = prefix_line_breaks(Some("line 1\nline 2"), "###").unwrap();
+///
+/// assert!(value.contains("### line 2"));
+/// ```
 pub fn prefix_line_breaks(value: Option<&str>, prefix_value: &str) -> Option<String> {
     value.map(|value| {
         let newline = if cfg!(windows) { "\r\n" } else { "\n" };

--- a/src/rust/core/src/support_information.rs
+++ b/src/rust/core/src/support_information.rs
@@ -3,6 +3,11 @@ use std::{env, ffi::OsString};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use sha2::{Digest, Sha256};
 
+/// Returns an anonymous, deterministic support identity for the current machine.
+///
+/// The identity is a lowercased base64-encoded SHA-256 hash of
+/// `user@machine`. It is intended for correlating support diagnostics without
+/// exposing the raw user or host name.
 pub fn anonymous_identity() -> String {
     let user_name = current_user_name();
     let machine_name = current_machine_name();
@@ -10,6 +15,19 @@ pub fn anonymous_identity() -> String {
     anonymous_identity_from_parts(&user_name, machine_name.as_deref())
 }
 
+/// Builds an anonymous support identity from explicit user and machine parts.
+///
+/// Empty or missing machine names are normalized to `localhost`.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::anonymous_identity_from_parts;
+///
+/// let identity = anonymous_identity_from_parts("alice", Some("build-agent"));
+///
+/// assert_eq!(identity.len(), 44);
+/// ```
 pub fn anonymous_identity_from_parts(user_name: &str, machine_name: Option<&str>) -> String {
     let machine_name = machine_name
         .map(str::trim)
@@ -21,10 +39,22 @@ pub fn anonymous_identity_from_parts(user_name: &str, machine_name: Option<&str>
     STANDARD.encode(hash).to_ascii_lowercase()
 }
 
+/// Returns a short support key for the current machine.
+///
+/// The key is the first seven characters of [`anonymous_identity`].
 pub fn support_key() -> String {
     support_key_from_anonymous_identity(&anonymous_identity())
 }
 
+/// Returns a short support key from a previously computed anonymous identity.
+///
+/// # Example
+///
+/// ```
+/// use httpgenerator_core::support_key_from_anonymous_identity;
+///
+/// assert_eq!(support_key_from_anonymous_identity("abcdefghi"), "abcdefg");
+/// ```
 pub fn support_key_from_anonymous_identity(anonymous_identity: &str) -> String {
     anonymous_identity.chars().take(7).collect()
 }


### PR DESCRIPTION
`httpgenerator-core` is the public library surface shown on docs.rs, but many exported items lacked rustdoc. This change makes the crate documentation more useful for downstream users by explaining the main generation flow, normalized model, OpenAPI helpers, and public utility APIs.

## Summary

- Adds crate-level and module-level rustdoc that guides users through generation, normalization, and OpenAPI loading.
- Documents public structs, fields, enum variants, functions, and error variants across the core, normalized, OpenAPI, and helper APIs.
- Adds practical rustdoc examples, using compile-tested examples where possible and `no_run` for file or URL loading flows.
- Enables `#![warn(missing_docs)]` so future public API documentation gaps are visible without blocking development.
- Fixes intra-doc links so docs build cleanly under rustdoc warnings.

## Validation

- `RUSTDOCFLAGS="-D warnings" cargo doc -p httpgenerator-core --no-deps`
- `cargo test --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive API documentation and usage examples throughout the library for improved developer experience.

* **New Features**
  * Enhanced `OpenApiInspection` to include statistics for better document analysis.
  * Improved public API exports for enhanced convenience and discoverability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christianhelle/httpgenerator/pull/405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->