### PR TITLE
Use HashMap in generate_http_files for buffer lookup

### DIFF
--- a/src/rust/core/src/generator/modes.rs
+++ b/src/rust/core/src/generator/modes.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::{
     GeneratorResult, GeneratorSettings, HttpFile, NormalizedOpenApiDocument, OutputType,
@@ -78,26 +78,25 @@ pub fn generate_http_files(
     );
 
     let mut buffers: Vec<HttpFileBuffer> = Vec::new();
+    let mut key_to_index: HashMap<String, usize> = HashMap::new();
     let mut seen_filenames = HashSet::new();
 
     for operation in &document.operations {
         let target = render_target(settings.output_type, operation, &mut seen_filenames);
-        let buffer = if let Some(index) = buffers.iter().position(|buffer| buffer.key == target.key)
-        {
-            &mut buffers[index].content
-        } else {
-            buffers.push(HttpFileBuffer {
-                key: target.key,
-                filename: target.filename,
-                content: String::new(),
+        let key = target.key.clone();
+        let index = key_to_index
+            .entry(key)
+            .or_insert_with(|| {
+                let idx = buffers.len();
+                buffers.push(HttpFileBuffer {
+                    filename: target.filename,
+                    content: String::new(),
+                });
+                write_file_headers(settings, &mut buffers[idx].content, &base_url);
+                idx
             });
-            let buffer = buffers.last_mut().expect("file buffer was just added");
-            write_file_headers(settings, &mut buffer.content, &base_url);
-            &mut buffer.content
-        };
-
-        buffer.push_str(&render_request(settings, operation));
-        push_blank_line(buffer);
+        buffers[*index].content.push_str(&render_request(settings, operation));
+        push_blank_line(&mut buffers[*index].content);
     }
 
     GeneratorResult::new(
@@ -109,7 +108,6 @@ pub fn generate_http_files(
 }
 
 struct HttpFileBuffer {
-    key: String,
     filename: String,
     content: String,
 }

--- a/src/rust/core/tests/facade_contracts.rs
+++ b/src/rust/core/tests/facade_contracts.rs
@@ -29,6 +29,57 @@ fn facade_modules_expose_expected_public_types_and_signatures() {
         openapi::OpenApiDocumentNormalizationError,
     > = openapi::load_and_normalize_document;
 
+    // Type-level assertions for the remaining public loader entry points.
+    let _: fn(
+        &str,
+        openapi::LoadOptions,
+    ) -> Result<openapi::LoadedOpenApiDocument, openapi::OpenApiDocumentLoadError> =
+        openapi::load_document;
+    let _: fn(
+        openapi::OpenApiSource,
+        openapi::LoadOptions,
+    ) -> Result<openapi::LoadedOpenApiDocument, openapi::OpenApiDocumentLoadError> =
+        openapi::load_document_from_source;
+    let _: fn(
+        openapi::RawOpenApiDocument,
+        openapi::LoadOptions,
+    ) -> Result<openapi::LoadedOpenApiDocument, openapi::OpenApiDocumentLoadError> =
+        openapi::load_document_from_raw;
+    let _: fn(
+        &openapi::LoadedOpenApiDocument,
+    ) -> Result<normalized::NormalizedOpenApiDocument, openapi::OpenApiNormalizationError> =
+        openapi::normalize_loaded_document;
+    let _: fn(
+        &str,
+    ) -> Result<openapi::RawOpenApiDocument, openapi::RawOpenApiLoadError> =
+        openapi::load_raw_document;
+    let _: fn(
+        openapi::OpenApiSource,
+    ) -> Result<openapi::RawOpenApiDocument, openapi::RawOpenApiLoadError> =
+        openapi::load_raw_document_from_source;
+    let _: fn(
+        &str,
+    ) -> Result<openapi::OpenApiInspection, openapi::OpenApiInspectionError> =
+        openapi::inspect_document;
+    let _: fn(
+        &openapi::RawOpenApiDocument,
+    ) -> Result<openapi::OpenApiInspection, openapi::OpenApiInspectionError> =
+        openapi::inspect_raw_document;
+    let _: fn(
+        &str,
+    ) -> Result<openapi::OpenApiSource, openapi::SourceClassificationError> =
+        openapi::classify_source;
+    let _: fn(
+        &serde_json::Value,
+    ) -> Result<
+        openapi::OpenApiSpecificationVersion,
+        openapi::SpecificationVersionDetectionError,
+    > = openapi::detect_specification_version;
+    let _: fn(
+        &openapi::RawOpenApiDocument,
+    ) -> Result<openapi::TypedOpenApiDocument, openapi::TypedOpenApiParseError> =
+        openapi::parse_typed_document;
+
     let settings = model::GeneratorSettings {
         open_api_path: "petstore.json".to_string(),
         output_type: model::OutputType::OneRequestPerFile,


### PR DESCRIPTION
## perf: replace O(n^2) position scan with HashMap in `generate_http_files`

- Replace `buffers.iter().position()` with `HashMap<String, usize>` index keyed by target filename, reducing buffer lookup from O(n) to O(1) per operation (O(n) total vs O(n^2) before).
- Remove now-redundant `HttpFileBuffer.key` field.

## test: add type assertions for all public openapi loader entry points

- Pin signatures of `load_document`, `load_document_from_source`, and `load_document_from_raw` to catch future signature drift.
- Also assert `normalize_loaded_document`, `load_raw_document`, `load_raw_document_from_source`, `inspect_document`, `inspect_raw_document`, `classify_source`, `detect_specification_version`, and `parse_typed_document` so the entire openapi facade surface is locked by the compile-time test.

## Validation

- All 132 tests pass (87 unit + 2 facade + 6 parity + 37 doc-tests).
- No new clippy warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized buffer management in HTTP file generation through improved operation deduplication strategy.

* **Tests**
  * Enhanced compile-time type safety by adding comprehensive type-level assertions for OpenAPI loader, normalizer, and inspection functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->