### PR TITLE
Upgrade Rust to 1.96

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2024"
 homepage = "https://christianhelle.com/httpgenerator/"
 license = "MIT"
 repository = "https://github.com/christianhelle/httpgenerator"
-rust-version = "1.95"
+rust-version = "1.96"
 version = "0.1.0"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cargo install httpgenerator
 ```
 
 Use this when you already have Rust and Cargo and want the canonical
-Rust ecosystem install path. Requires Rust 1.95+.
+Rust ecosystem install path. Requires Rust 1.96+.
 
 #### macOS/Linux
 


### PR DESCRIPTION
## Summary

- Bump workspace rust-version from 1.95 to 1.96 in Cargo.toml
- Update README to reflect the new Rust version requirement

## Changes

- Cargo.toml: rust-version = 1.96
- README.md: Rust 1.96+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation requirements to reflect the new minimum Rust version.

* **Chores**
  * Updated minimum supported Rust compiler version from 1.95 to 1.96.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->